### PR TITLE
Add Archon E2E smoke marker

### DIFF
--- a/archon-e2e/2026-04-30T20-00-23-729Z.md
+++ b/archon-e2e/2026-04-30T20-00-23-729Z.md
@@ -1,0 +1,1 @@
+Session 2026-04-30T20-00-23-729Z completed the e2e marker.


### PR DESCRIPTION
## Summary

Adds the Archon E2E smoke marker for session `2026-04-30T20-00-23-729Z`.

## Changes

- Created `archon-e2e/2026-04-30T20-00-23-729Z.md` with exactly one short sentence containing the session id.
- Left source code, package files, lockfiles, CI, and existing documentation unchanged.

## Validation Evidence

- `git diff --check` passed.
- Structural acceptance passed: exactly one changed file, expected marker path, one-line file content, and required session id present.
- PR readiness passed: clean worktree on `archon-e2e/2026-04-30T20-00-23-729Z` with commit `51cf3b6 Add Archon E2E smoke marker`.
- Type check, lint, tests, and build are not applicable because the repository has no package manifest, runtime toolchain, or test framework.

Fixes #4