### PR TITLE
test: add Archon E2E smoke marker

### DIFF
--- a/archon-e2e/2026-04-30T20-13-44-187Z.md
+++ b/archon-e2e/2026-04-30T20-13-44-187Z.md
@@ -1,0 +1,1 @@
+Archon E2E smoke test 2026-04-30T20-13-44-187Z completed.


### PR DESCRIPTION
## Summary
- Adds one disposable Archon E2E smoke marker file.
- Session: `2026-04-30T20-13-44-187Z`
- File: `archon-e2e/2026-04-30T20-13-44-187Z.md`

## Validation
- Created by `archon-e2e-tiny`.
- Scoped to `archon-e2e`.

Closes #7