### PR TITLE
test: add Archon E2E self-merge marker

### DIFF
--- a/archon-e2e/2026-04-30T20-36-33-498Z-24.md
+++ b/archon-e2e/2026-04-30T20-36-33-498Z-24.md
@@ -1,0 +1,1 @@
+Archon E2E self-merge smoke test 2026-04-30T20-36-33-498Z issue 24 completed.


### PR DESCRIPTION
## Summary
- Adds one disposable Archon E2E self-merge marker file.
- Session: `2026-04-30T20-36-33-498Z`
- File: `archon-e2e/2026-04-30T20-36-33-498Z-24.md`

## Validation
- Created by `archon-e2e-tiny-self-merge`.
- Scoped to `archon-e2e`.

Closes #24