### PR TITLE
Ecommerce Catalog Interactions

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -20,10 +20,34 @@ describe("renderStorefront", () => {
     expect(html).toContain("Weekend Tote");
   });
 
+  it("renders catalog browsing controls", () => {
+    const html = renderStorefront(products);
+
+    expect(html).toContain("Search products");
+    expect(html).toContain('id="catalog-search"');
+    expect(html).toContain('id="catalog-category"');
+    expect(html).toContain("All categories");
+    expect(html).toContain("Workspace");
+    expect(html).toContain("Drinkware");
+    expect(html).toContain("Bags");
+    expect(html).toContain('id="catalog-sort"');
+    expect(html).toContain("Featured");
+    expect(html).toContain("Price: low to high");
+    expect(html).toContain("Price: high to low");
+  });
+
+  it("renders a catalog result count", () => {
+    const html = renderStorefront(products);
+
+    expect(html).toContain('class="catalog-results__summary"');
+    expect(html).toContain("3 products");
+  });
+
   it("renders shell placeholders with an empty catalog", () => {
     const html = renderStorefront([]);
 
     expect(html).toContain("Featured products");
+    expect(html).toContain("No products match your search.");
     expect(html).toContain("0 items");
     expect(html).toContain("$0.00");
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,19 @@ import "./styles.css";
 import {
   calculateCartSummary,
   formatPrice,
+  getVisibleProducts,
   products,
+  type CatalogBrowseOptions,
+  type CatalogSort,
   type Product,
+  type ProductCategory,
 } from "./storefront";
+
+const categoryLabels: Record<ProductCategory, string> = {
+  workspace: "Workspace",
+  drinkware: "Drinkware",
+  bags: "Bags",
+};
 
 function renderProductCard(product: Product): string {
   return `
@@ -24,9 +34,62 @@ function renderProductCard(product: Product): string {
   `;
 }
 
+function getCatalogCategories(catalog: Product[]): ProductCategory[] {
+  return Array.from(new Set(catalog.map((product) => product.category)));
+}
+
+function renderCatalogControls(catalog: Product[]): string {
+  const categoryOptions = getCatalogCategories(catalog)
+    .map(
+      (category) =>
+        `<option value="${category}">${categoryLabels[category]}</option>`,
+    )
+    .join("");
+
+  return `
+    <div class="catalog-toolbar" aria-label="Catalog browsing controls">
+      <label class="catalog-toolbar__field">
+        <span>Search products</span>
+        <input id="catalog-search" type="search" name="catalog-search" placeholder="Search by name or detail" />
+      </label>
+      <label class="catalog-toolbar__field">
+        <span>Category</span>
+        <select id="catalog-category" name="catalog-category">
+          <option value="all">All categories</option>
+          ${categoryOptions}
+        </select>
+      </label>
+      <label class="catalog-toolbar__field">
+        <span>Sort by</span>
+        <select id="catalog-sort" name="catalog-sort">
+          <option value="featured">Featured</option>
+          <option value="price-asc">Price: low to high</option>
+          <option value="price-desc">Price: high to low</option>
+        </select>
+      </label>
+    </div>
+  `;
+}
+
+function renderCatalogResults(visibleProducts: Product[]): string {
+  const productLabel = visibleProducts.length === 1 ? "product" : "products";
+  const productCards = visibleProducts.map(renderProductCard).join("");
+
+  return `
+    <p class="catalog-results__summary" aria-live="polite">
+      ${visibleProducts.length} ${productLabel}
+    </p>
+    ${
+      visibleProducts.length === 0
+        ? `<p class="catalog-empty">No products match your search.</p>`
+        : `<div class="product-grid">${productCards}</div>`
+    }
+  `;
+}
+
 export function renderStorefront(catalog: Product[] = products): string {
   const cartSummary = calculateCartSummary([], catalog);
-  const productCards = catalog.map(renderProductCard).join("");
+  const visibleProducts = getVisibleProducts(catalog);
 
   return `
     <header class="site-header">
@@ -55,8 +118,9 @@ export function renderStorefront(catalog: Product[] = products): string {
           <p class="eyebrow">Catalog</p>
           <h2 id="products-title">Featured products</h2>
         </div>
-        <div class="product-grid">
-          ${productCards}
+        ${renderCatalogControls(catalog)}
+        <div id="catalog-results" class="catalog-results">
+          ${renderCatalogResults(visibleProducts)}
         </div>
       </section>
 
@@ -84,6 +148,41 @@ export function renderStorefront(catalog: Product[] = products): string {
   `;
 }
 
+function readCatalogOptions(): CatalogBrowseOptions {
+  const search = document.querySelector<HTMLInputElement>("#catalog-search");
+  const category =
+    document.querySelector<HTMLSelectElement>("#catalog-category");
+  const sort = document.querySelector<HTMLSelectElement>("#catalog-sort");
+
+  return {
+    category: category?.value as CatalogBrowseOptions["category"],
+    query: search?.value,
+    sort: sort?.value as CatalogSort,
+  };
+}
+
+function bindCatalogControls(): void {
+  const search = document.querySelector<HTMLInputElement>("#catalog-search");
+  const category =
+    document.querySelector<HTMLSelectElement>("#catalog-category");
+  const sort = document.querySelector<HTMLSelectElement>("#catalog-sort");
+  const results = document.querySelector<HTMLDivElement>("#catalog-results");
+
+  if (!search || !category || !sort || !results) {
+    return;
+  }
+
+  const updateResults = () => {
+    results.innerHTML = renderCatalogResults(
+      getVisibleProducts(products, readCatalogOptions()),
+    );
+  };
+
+  search.addEventListener("input", updateResults);
+  category.addEventListener("change", updateResults);
+  sort.addEventListener("change", updateResults);
+}
+
 const app =
   typeof document === "undefined"
     ? null
@@ -91,4 +190,5 @@ const app =
 
 if (app) {
   app.innerHTML = renderStorefront(products);
+  bindCatalogControls();
 }

--- a/src/storefront.test.ts
+++ b/src/storefront.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { calculateCartSummary, formatPrice, products } from "./storefront";
+import {
+  calculateCartSummary,
+  formatPrice,
+  getVisibleProducts,
+  products,
+} from "./storefront";
 
 describe("storefront helpers", () => {
   it("formats product prices in USD", () => {
@@ -38,5 +43,73 @@ describe("storefront helpers", () => {
       itemCount: 0,
       subtotalCents: 0,
     });
+  });
+
+  it("filters products by category", () => {
+    expect(
+      getVisibleProducts(products, { category: "drinkware" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["travel-tumbler"]);
+  });
+
+  it("searches product names case-insensitively", () => {
+    expect(
+      getVisibleProducts(products, { query: "desk" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["desk-starter-kit"]);
+  });
+
+  it("searches product descriptions case-insensitively", () => {
+    expect(
+      getVisibleProducts(products, { query: "COMMUTES" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["travel-tumbler"]);
+  });
+
+  it("treats a blank query like no query", () => {
+    expect(
+      getVisibleProducts(products, { category: "bags", query: "   " }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["weekend-tote"]);
+  });
+
+  it("sorts products by price ascending and descending", () => {
+    expect(
+      getVisibleProducts(products, { sort: "price-asc" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["travel-tumbler", "desk-starter-kit", "weekend-tote"]);
+
+    expect(
+      getVisibleProducts(products, { sort: "price-desc" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["weekend-tote", "desk-starter-kit", "travel-tumbler"]);
+  });
+
+  it("preserves source order for featured sorting", () => {
+    expect(getVisibleProducts(products).map((product) => product.id)).toEqual([
+      "desk-starter-kit",
+      "travel-tumbler",
+      "weekend-tote",
+    ]);
+
+    expect(
+      getVisibleProducts(products, { sort: "featured" }).map(
+        (product) => product.id,
+      ),
+    ).toEqual(["desk-starter-kit", "travel-tumbler", "weekend-tote"]);
+  });
+
+  it("does not mutate the original product order when sorting", () => {
+    const originalOrder = products.map((product) => product.id);
+
+    getVisibleProducts(products, { sort: "price-desc" });
+
+    expect(products.map((product) => product.id)).toEqual(originalOrder);
   });
 });

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -1,7 +1,18 @@
+export type ProductCategory = "workspace" | "drinkware" | "bags";
+
+export type CatalogSort = "featured" | "price-asc" | "price-desc";
+
+export type CatalogBrowseOptions = {
+  category?: ProductCategory | "all";
+  query?: string;
+  sort?: CatalogSort;
+};
+
 export type Product = {
   id: string;
   name: string;
   description: string;
+  category: ProductCategory;
   priceCents: number;
   imageAlt: string;
 };
@@ -22,6 +33,7 @@ export const products: Product[] = [
     name: "Desk Starter Kit",
     description:
       "A focused bundle with a notebook, cable clips, and a compact desk tray.",
+    category: "workspace",
     priceCents: 5400,
     imageAlt: "Desk organizer kit",
   },
@@ -30,6 +42,7 @@ export const products: Product[] = [
     name: "Travel Tumbler",
     description:
       "A stainless tumbler with a leak-resistant lid for commutes and meetings.",
+    category: "drinkware",
     priceCents: 3200,
     imageAlt: "Stainless travel tumbler",
   },
@@ -38,6 +51,7 @@ export const products: Product[] = [
     name: "Weekend Tote",
     description:
       "A sturdy canvas tote sized for daily errands, books, and light travel.",
+    category: "bags",
     priceCents: 6800,
     imageAlt: "Canvas weekend tote",
   },
@@ -48,6 +62,39 @@ export function formatPrice(priceCents: number): string {
     style: "currency",
     currency: "USD",
   }).format(priceCents / 100);
+}
+
+export function getVisibleProducts(
+  catalog: Product[],
+  options: CatalogBrowseOptions = {},
+): Product[] {
+  const query = options.query?.trim().toLowerCase() ?? "";
+  const category = options.category ?? "all";
+  const sort = options.sort ?? "featured";
+
+  const filtered = catalog.filter((product) => {
+    const matchesCategory = category === "all" || product.category === category;
+    const matchesQuery =
+      query.length === 0 ||
+      product.name.toLowerCase().includes(query) ||
+      product.description.toLowerCase().includes(query);
+
+    return matchesCategory && matchesQuery;
+  });
+
+  if (sort === "price-asc") {
+    return [...filtered].sort(
+      (first, second) => first.priceCents - second.priceCents,
+    );
+  }
+
+  if (sort === "price-desc") {
+    return [...filtered].sort(
+      (first, second) => second.priceCents - first.priceCents,
+    );
+  }
+
+  return filtered;
 }
 
 export function calculateCartSummary(

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,6 +123,53 @@ main {
   margin: 0.25rem 0 0;
 }
 
+.catalog-toolbar {
+  background: #ffffff;
+  border: 1px solid #ded8cf;
+  border-radius: 8px;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.catalog-toolbar__field {
+  color: #1d252c;
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 700;
+}
+
+.catalog-toolbar__field span {
+  font-size: 0.88rem;
+}
+
+.catalog-toolbar__field input,
+.catalog-toolbar__field select {
+  background: #ffffff;
+  border: 1px solid #ded8cf;
+  border-radius: 6px;
+  color: #1d252c;
+  font: inherit;
+  min-width: 0;
+  padding: 0.7rem 0.75rem;
+}
+
+.catalog-results__summary {
+  color: #4d5963;
+  font-weight: 700;
+  margin: 0 0 1rem;
+}
+
+.catalog-empty {
+  background: #ffffff;
+  border: 1px solid #ded8cf;
+  border-radius: 8px;
+  color: #4d5963;
+  padding: 1rem;
+}
+
 .product-grid {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary

Add real catalog browsing to the existing framework-free Vite storefront by extending products with categories, adding pure catalog query helpers, and wiring local search/filter/sort controls into the products section. The change stays static and local-only, with cart and checkout placeholders unchanged.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/storefront.ts` | UPDATE | Added product categories, catalog browse option types, and `getVisibleProducts` for category filtering, text search, and price sorting. |
| `src/storefront.test.ts` | UPDATE | Added helper coverage for category filtering, case-insensitive search, blank query handling, price sorting, featured ordering, and mutation safety. |
| `src/main.ts` | UPDATE | Added catalog controls, result counts, empty-state rendering, and browser interaction wiring for search, category, and sort changes. |
| `src/main.test.ts` | UPDATE | Added rendered UI assertions for catalog controls and result count, and updated empty catalog copy coverage. |
| `src/styles.css` | UPDATE | Added scoped styles for catalog toolbar controls, result summary, and empty catalog state. |

## Tests

- `src/storefront.test.ts` - Added tests for category filtering, name and description search, blank query handling, ascending and descending price sorting, featured ordering, and source-order mutation safety.
- `src/main.test.ts` - Added tests for rendered catalog controls and catalog result count; updated empty catalog test for the new empty-state copy.

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] Focused tests pass (16 tests)
- [x] All tests pass (16 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

No deviations. Implementation matched the plan exactly.

### Issues Resolved

- Resolved a Prettier formatting warning in `src/storefront.ts` by formatting touched files and rerunning validation successfully.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/3a9b727d435be94da0da31cd059a05cd/plan.md`
**Workflow ID**: `3a9b727d435be94da0da31cd059a05cd`

Fixes #56
