### PR TITLE
Ecommerce Cart and Checkout

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,8 +8,9 @@ describe("renderStorefront", () => {
 
     expect(html).toContain("X15 Store");
     expect(html).toContain('id="products"');
-    expect(html).toContain('aria-label="Cart summary placeholder"');
-    expect(html).toContain("Checkout placeholder");
+    expect(html).toContain('aria-label="Cart totals"');
+    expect(html).toContain("Checkout details");
+    expect(html).toContain("data-checkout-form");
   });
 
   it("renders product cards for the starter catalog", () => {
@@ -18,6 +19,8 @@ describe("renderStorefront", () => {
     expect(html).toContain("Desk Starter Kit");
     expect(html).toContain("Travel Tumbler");
     expect(html).toContain("Weekend Tote");
+    expect(html).toContain('data-cart-add="desk-starter-kit"');
+    expect(html).toContain("Add to cart");
   });
 
   it("renders catalog browsing controls", () => {
@@ -43,12 +46,53 @@ describe("renderStorefront", () => {
     expect(html).toContain("3 products");
   });
 
-  it("renders shell placeholders with an empty catalog", () => {
+  it("renders an empty catalog and cart with zero totals", () => {
     const html = renderStorefront([]);
 
     expect(html).toContain("Featured products");
     expect(html).toContain("No products match your search.");
-    expect(html).toContain("0 items");
+    expect(html).toContain("Your cart is empty.");
+    expect(html).toContain("0 products");
     expect(html).toContain("$0.00");
+    expect(html).toContain("<dd>0</dd>");
+  });
+
+  it("renders cart rows and totals from state", () => {
+    const html = renderStorefront(products, {
+      cartItems: [{ productId: "desk-starter-kit", quantity: 2 }],
+    });
+
+    expect(html).toContain("Desk Starter Kit");
+    expect(html).toContain('value="2"');
+    expect(html).toContain("$108.00");
+    expect(html).toContain("$5.00");
+    expect(html).toContain("$8.64");
+    expect(html).toContain("$121.64");
+  });
+
+  it("renders checkout validation errors from state", () => {
+    const html = renderStorefront(products, {
+      checkoutErrors: {
+        name: "Enter your name.",
+        email: "Enter a valid email address.",
+        shippingAddress: "Enter a shipping address.",
+        cart: "Add at least one catalog item to checkout.",
+      },
+    });
+
+    expect(html).toContain("Enter your name.");
+    expect(html).toContain("Enter a valid email address.");
+    expect(html).toContain("Enter a shipping address.");
+    expect(html).toContain("Add at least one catalog item to checkout.");
+  });
+
+  it("renders order confirmation when provided", () => {
+    const html = renderStorefront(products, {
+      confirmationId: "X15-ABC1234",
+    });
+
+    expect(html).toContain("Order confirmed");
+    expect(html).toContain("X15-ABC1234");
+    expect(html).toContain('aria-live="polite"');
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,18 @@
 import "./styles.css";
 import {
-  calculateCartSummary,
+  addCartItem,
+  calculateCartTotal,
+  createOrderConfirmationId,
   formatPrice,
   getVisibleProducts,
   products,
+  removeCartItem,
+  updateCartItemQuantity,
+  validateCheckout,
   type CatalogBrowseOptions,
   type CatalogSort,
+  type CartItem,
+  type CheckoutValidationResult,
   type Product,
   type ProductCategory,
 } from "./storefront";
@@ -28,7 +35,7 @@ function renderProductCard(product: Product): string {
       </div>
       <div class="product-card__footer">
         <strong>${formatPrice(product.priceCents)}</strong>
-        <button type="button" disabled>Add soon</button>
+        <button type="button" data-cart-add="${product.id}">Add to cart</button>
       </div>
     </article>
   `;
@@ -87,9 +94,69 @@ function renderCatalogResults(visibleProducts: Product[]): string {
   `;
 }
 
-export function renderStorefront(catalog: Product[] = products): string {
-  const cartSummary = calculateCartSummary([], catalog);
+type StorefrontRenderState = {
+  cartItems?: CartItem[];
+  checkoutErrors?: CheckoutValidationResult["errors"];
+  confirmationId?: string;
+};
+
+function renderCartLines(cartItems: CartItem[], catalog: Product[]): string {
+  const catalogById = new Map(catalog.map((product) => [product.id, product]));
+  const lines = cartItems
+    .map((item) => {
+      const product = catalogById.get(item.productId);
+
+      if (!product) {
+        return "";
+      }
+
+      return `
+        <li class="cart-line">
+          <div>
+            <strong>${product.name}</strong>
+            <span>${formatPrice(product.priceCents)} each</span>
+          </div>
+          <div class="cart-line__actions">
+            <button type="button" aria-label="Decrease ${product.name}" data-cart-decrement="${product.id}">-</button>
+            <input type="number" min="0" value="${item.quantity}" aria-label="${product.name} quantity" data-cart-quantity="${product.id}" />
+            <button type="button" aria-label="Increase ${product.name}" data-cart-increment="${product.id}">+</button>
+            <button type="button" data-cart-remove="${product.id}">Remove</button>
+          </div>
+          <strong>${formatPrice(product.priceCents * item.quantity)}</strong>
+        </li>
+      `;
+    })
+    .filter(Boolean)
+    .join("");
+
+  if (!lines) {
+    return `<p class="empty-cart">Your cart is empty.</p>`;
+  }
+
+  return `<ul class="cart-list">${lines}</ul>`;
+}
+
+function renderFieldError(error?: string): string {
+  return error ? `<p class="field__error">${error}</p>` : "";
+}
+
+export function renderStorefront(
+  catalog: Product[] = products,
+  state: StorefrontRenderState = {},
+): string {
+  const cartItems = state.cartItems ?? [];
+  const cartSummary = calculateCartTotal(cartItems, catalog);
   const visibleProducts = getVisibleProducts(catalog);
+  const cartLines = renderCartLines(cartItems, catalog);
+  const checkoutErrors = state.checkoutErrors ?? {};
+  const confirmationPanel = state.confirmationId
+    ? `
+        <aside class="confirmation-panel" aria-live="polite">
+          <span>Order confirmed</span>
+          <strong>${state.confirmationId}</strong>
+        </aside>
+      `
+    : "";
 
   return `
     <header class="site-header">
@@ -108,8 +175,8 @@ export function renderStorefront(catalog: Product[] = products): string {
         <p class="eyebrow">Minimal ecommerce foundation</p>
         <h1 id="intro-title">A small storefront shell for X15.</h1>
         <p>
-          Browse a starter catalog, review the cart placeholder, and keep checkout
-          ready for future product work.
+          Browse a starter catalog, update an in-memory cart, and confirm checkout
+          details without payments or accounts.
         </p>
       </section>
 
@@ -128,21 +195,59 @@ export function renderStorefront(catalog: Product[] = products): string {
         <div>
           <p class="eyebrow">Cart</p>
           <h2 id="cart-title">Cart summary</h2>
-          <p>Your cart is ready for future item selection work.</p>
+          ${cartLines}
+          ${renderFieldError(checkoutErrors.cart)}
         </div>
-        <aside class="summary-panel" aria-label="Cart summary placeholder">
-          <span>${cartSummary.itemCount} items</span>
-          <strong>${formatPrice(cartSummary.subtotalCents)}</strong>
+        <aside class="summary-panel" aria-label="Cart totals">
+          <dl class="totals-list">
+            <div>
+              <dt>Items</dt>
+              <dd>${cartSummary.itemCount}</dd>
+            </div>
+            <div>
+              <dt>Subtotal</dt>
+              <dd>${formatPrice(cartSummary.subtotalCents)}</dd>
+            </div>
+            <div>
+              <dt>Shipping</dt>
+              <dd>${formatPrice(cartSummary.shippingCents)}</dd>
+            </div>
+            <div>
+              <dt>Tax</dt>
+              <dd>${formatPrice(cartSummary.taxCents)}</dd>
+            </div>
+            <div class="totals-list__total">
+              <dt>Total</dt>
+              <dd>${formatPrice(cartSummary.totalCents)}</dd>
+            </div>
+          </dl>
         </aside>
       </section>
 
       <section id="checkout" class="store-section store-section--split" aria-labelledby="checkout-title">
         <div>
           <p class="eyebrow">Checkout</p>
-          <h2 id="checkout-title">Checkout placeholder</h2>
-          <p>Payment, shipping, accounts, and fulfillment are intentionally out of scope.</p>
+          <h2 id="checkout-title">Checkout details</h2>
+          <form class="checkout-form" data-checkout-form>
+            <label class="field">
+              <span>Name</span>
+              <input name="name" autocomplete="name" />
+              ${renderFieldError(checkoutErrors.name)}
+            </label>
+            <label class="field">
+              <span>Email</span>
+              <input name="email" autocomplete="email" />
+              ${renderFieldError(checkoutErrors.email)}
+            </label>
+            <label class="field">
+              <span>Shipping address</span>
+              <textarea name="shippingAddress" rows="3" autocomplete="shipping street-address"></textarea>
+              ${renderFieldError(checkoutErrors.shippingAddress)}
+            </label>
+            <button type="submit">Confirm order</button>
+          </form>
         </div>
-        <button type="button" disabled>Checkout coming soon</button>
+        ${confirmationPanel}
       </section>
     </main>
   `;
@@ -189,6 +294,100 @@ const app =
     : document.querySelector<HTMLDivElement>("#app");
 
 if (app) {
-  app.innerHTML = renderStorefront(products);
-  bindCatalogControls();
+  let cartItems: CartItem[] = [];
+  let checkoutErrors: CheckoutValidationResult["errors"] = {};
+  let confirmationId = "";
+
+  const render = () => {
+    app.innerHTML = renderStorefront(products, {
+      cartItems,
+      checkoutErrors,
+      confirmationId,
+    });
+    bindCatalogControls();
+  };
+
+  app.addEventListener("click", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const addProductId = target.dataset.cartAdd;
+    const removeProductId = target.dataset.cartRemove;
+    const incrementProductId = target.dataset.cartIncrement;
+    const decrementProductId = target.dataset.cartDecrement;
+
+    if (addProductId) {
+      cartItems = addCartItem(cartItems, addProductId);
+    } else if (removeProductId) {
+      cartItems = removeCartItem(cartItems, removeProductId);
+    } else if (incrementProductId) {
+      cartItems = addCartItem(cartItems, incrementProductId);
+    } else if (decrementProductId) {
+      const currentItem = cartItems.find(
+        (item) => item.productId === decrementProductId,
+      );
+
+      if (!currentItem) {
+        return;
+      }
+
+      cartItems = updateCartItemQuantity(
+        cartItems,
+        decrementProductId,
+        currentItem.quantity - 1,
+      );
+    } else {
+      return;
+    }
+
+    checkoutErrors = {};
+    confirmationId = "";
+    render();
+  });
+
+  app.addEventListener("change", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement) || !target.dataset.cartQuantity) {
+      return;
+    }
+
+    cartItems = updateCartItemQuantity(
+      cartItems,
+      target.dataset.cartQuantity,
+      Number.parseInt(target.value, 10) || 0,
+    );
+    checkoutErrors = {};
+    confirmationId = "";
+    render();
+  });
+
+  app.addEventListener("submit", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof HTMLFormElement) || !target.dataset.checkoutForm) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const formData = new FormData(target);
+    const details = {
+      name: String(formData.get("name") ?? ""),
+      email: String(formData.get("email") ?? ""),
+      shippingAddress: String(formData.get("shippingAddress") ?? ""),
+    };
+    const validation = validateCheckout(details, cartItems, products);
+
+    checkoutErrors = validation.errors;
+    confirmationId = validation.isValid
+      ? createOrderConfirmationId(details, cartItems, products)
+      : "";
+    render();
+  });
+
+  render();
 }

--- a/src/storefront.test.ts
+++ b/src/storefront.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  addCartItem,
+  calculateCartSubtotal,
   calculateCartSummary,
+  calculateCartTotal,
+  calculateShipping,
+  calculateTax,
+  createOrderConfirmationId,
   formatPrice,
   getVisibleProducts,
   products,
+  removeCartItem,
+  updateCartItemQuantity,
+  validateCheckout,
 } from "./storefront";
 
 describe("storefront helpers", () => {
@@ -15,6 +24,9 @@ describe("storefront helpers", () => {
     expect(calculateCartSummary([], products)).toEqual({
       itemCount: 0,
       subtotalCents: 0,
+      shippingCents: 0,
+      taxCents: 0,
+      totalCents: 0,
     });
   });
 
@@ -30,6 +42,9 @@ describe("storefront helpers", () => {
     ).toEqual({
       itemCount: 5,
       subtotalCents: 20400,
+      shippingCents: 500,
+      taxCents: 1632,
+      totalCents: 22532,
     });
   });
 
@@ -42,6 +57,9 @@ describe("storefront helpers", () => {
     ).toEqual({
       itemCount: 0,
       subtotalCents: 0,
+      shippingCents: 0,
+      taxCents: 0,
+      totalCents: 0,
     });
   });
 
@@ -111,5 +129,127 @@ describe("storefront helpers", () => {
     getVisibleProducts(products, { sort: "price-desc" });
 
     expect(products.map((product) => product.id)).toEqual(originalOrder);
+  });
+
+  it("adds new cart lines and increments existing items without mutating input", () => {
+    const cartItems = [{ productId: "desk-starter-kit", quantity: 1 }];
+
+    expect(addCartItem([], "travel-tumbler")).toEqual([
+      { productId: "travel-tumbler", quantity: 1 },
+    ]);
+    expect(addCartItem(cartItems, "desk-starter-kit")).toEqual([
+      { productId: "desk-starter-kit", quantity: 2 },
+    ]);
+    expect(cartItems).toEqual([{ productId: "desk-starter-kit", quantity: 1 }]);
+  });
+
+  it("removes only the matching cart line", () => {
+    expect(
+      removeCartItem(
+        [
+          { productId: "desk-starter-kit", quantity: 1 },
+          { productId: "travel-tumbler", quantity: 2 },
+        ],
+        "desk-starter-kit",
+      ),
+    ).toEqual([{ productId: "travel-tumbler", quantity: 2 }]);
+  });
+
+  it("updates quantities and removes non-positive quantities", () => {
+    const cartItems = [
+      { productId: "desk-starter-kit", quantity: 1 },
+      { productId: "travel-tumbler", quantity: 2 },
+    ];
+
+    expect(updateCartItemQuantity(cartItems, "travel-tumbler", 4)).toEqual([
+      { productId: "desk-starter-kit", quantity: 1 },
+      { productId: "travel-tumbler", quantity: 4 },
+    ]);
+    expect(updateCartItemQuantity(cartItems, "travel-tumbler", 0)).toEqual([
+      { productId: "desk-starter-kit", quantity: 1 },
+    ]);
+  });
+
+  it("calculates subtotal, shipping, tax, and total deterministically", () => {
+    const cartItems = [{ productId: "desk-starter-kit", quantity: 2 }];
+
+    expect(calculateCartSubtotal(cartItems, products)).toBe(10800);
+    expect(
+      calculateCartSubtotal([{ productId: "missing", quantity: 3 }], products),
+    ).toBe(0);
+    expect(calculateShipping(0)).toBe(0);
+    expect(calculateShipping(10800)).toBe(500);
+    expect(calculateTax(10800)).toBe(864);
+    expect(calculateCartTotal(cartItems, products)).toEqual({
+      itemCount: 2,
+      subtotalCents: 10800,
+      shippingCents: 500,
+      taxCents: 864,
+      totalCents: 12164,
+    });
+  });
+
+  it("validates checkout details and rejects an empty cart", () => {
+    expect(
+      validateCheckout(
+        { name: " ", email: "bad-email", shippingAddress: "" },
+        [],
+        products,
+      ),
+    ).toEqual({
+      isValid: false,
+      errors: {
+        name: "Enter your name.",
+        email: "Enter a valid email address.",
+        shippingAddress: "Enter a shipping address.",
+        cart: "Add at least one catalog item to checkout.",
+      },
+    });
+  });
+
+  it("accepts valid checkout details with a known cart item", () => {
+    expect(
+      validateCheckout(
+        {
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          shippingAddress: "12 Algorithm Way",
+        },
+        [{ productId: "desk-starter-kit", quantity: 1 }],
+        products,
+      ),
+    ).toEqual({
+      isValid: true,
+      errors: {},
+    });
+  });
+
+  it("creates deterministic order confirmation ids independent of cart order", () => {
+    const details = {
+      name: " Ada Lovelace ",
+      email: "ADA@example.com",
+      shippingAddress: " 12 Algorithm Way ",
+    };
+    const firstCart = [
+      { productId: "desk-starter-kit", quantity: 1 },
+      { productId: "travel-tumbler", quantity: 2 },
+    ];
+    const secondCart = [
+      { productId: "travel-tumbler", quantity: 2 },
+      { productId: "desk-starter-kit", quantity: 1 },
+    ];
+    const confirmationId = createOrderConfirmationId(
+      details,
+      firstCart,
+      products,
+    );
+
+    expect(confirmationId).toMatch(/^X15-[0-9A-Z]+$/);
+    expect(createOrderConfirmationId(details, firstCart, products)).toBe(
+      confirmationId,
+    );
+    expect(createOrderConfirmationId(details, secondCart, products)).toBe(
+      confirmationId,
+    );
   });
 });

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -25,6 +25,30 @@ export type CartItem = {
 export type CartSummary = {
   itemCount: number;
   subtotalCents: number;
+  shippingCents: number;
+  taxCents: number;
+  totalCents: number;
+};
+
+export type CheckoutDetails = {
+  name: string;
+  email: string;
+  shippingAddress: string;
+};
+
+export type CheckoutValidationResult = {
+  isValid: boolean;
+  errors: {
+    name?: string;
+    email?: string;
+    shippingAddress?: string;
+    cart?: string;
+  };
+};
+
+type CartBaseSummary = {
+  itemCount: number;
+  subtotalCents: number;
 };
 
 export const products: Product[] = [
@@ -97,13 +121,51 @@ export function getVisibleProducts(
   return filtered;
 }
 
-export function calculateCartSummary(
+export function addCartItem(
+  cartItems: CartItem[],
+  productId: string,
+): CartItem[] {
+  const existingItem = cartItems.find((item) => item.productId === productId);
+
+  if (!existingItem) {
+    return [...cartItems, { productId, quantity: 1 }];
+  }
+
+  return cartItems.map((item) =>
+    item.productId === productId
+      ? { ...item, quantity: item.quantity + 1 }
+      : item,
+  );
+}
+
+export function removeCartItem(
+  cartItems: CartItem[],
+  productId: string,
+): CartItem[] {
+  return cartItems.filter((item) => item.productId !== productId);
+}
+
+export function updateCartItemQuantity(
+  cartItems: CartItem[],
+  productId: string,
+  quantity: number,
+): CartItem[] {
+  if (quantity <= 0) {
+    return removeCartItem(cartItems, productId);
+  }
+
+  return cartItems.map((item) =>
+    item.productId === productId ? { ...item, quantity } : item,
+  );
+}
+
+function calculateCartBaseSummary(
   cartItems: CartItem[],
   catalog: Product[],
-): CartSummary {
+): CartBaseSummary {
   const catalogById = new Map(catalog.map((product) => [product.id, product]));
 
-  return cartItems.reduce<CartSummary>(
+  return cartItems.reduce<CartBaseSummary>(
     (summary, item) => {
       const product = catalogById.get(item.productId);
 
@@ -122,4 +184,135 @@ export function calculateCartSummary(
       subtotalCents: 0,
     },
   );
+}
+
+export function calculateCartSubtotal(
+  cartItems: CartItem[],
+  catalog: Product[],
+): number {
+  return calculateCartBaseSummary(cartItems, catalog).subtotalCents;
+}
+
+export function calculateShipping(subtotalCents: number): number {
+  return subtotalCents > 0 ? 500 : 0;
+}
+
+export function calculateTax(subtotalCents: number): number {
+  return Math.round(subtotalCents * 0.08);
+}
+
+export function calculateCartTotal(
+  cartItems: CartItem[],
+  catalog: Product[],
+): CartSummary {
+  const baseSummary = calculateCartBaseSummary(cartItems, catalog);
+  const shippingCents = calculateShipping(baseSummary.subtotalCents);
+  const taxCents = calculateTax(baseSummary.subtotalCents);
+
+  return {
+    ...baseSummary,
+    shippingCents,
+    taxCents,
+    totalCents: baseSummary.subtotalCents + shippingCents + taxCents,
+  };
+}
+
+export function calculateCartSummary(
+  cartItems: CartItem[],
+  catalog: Product[],
+): CartSummary {
+  return calculateCartTotal(cartItems, catalog);
+}
+
+function hasValidEmailShape(email: string): boolean {
+  const atIndex = email.indexOf("@");
+  const hasSingleAt = atIndex !== -1 && atIndex === email.lastIndexOf("@");
+  const domain = hasSingleAt ? email.slice(atIndex + 1) : "";
+
+  return (
+    hasSingleAt && atIndex > 0 && domain.includes(".") && !domain.endsWith(".")
+  );
+}
+
+function normalizeCheckoutDetails(details: CheckoutDetails): CheckoutDetails {
+  return {
+    name: details.name.trim().toLowerCase(),
+    email: details.email.trim().toLowerCase(),
+    shippingAddress: details.shippingAddress.trim().toLowerCase(),
+  };
+}
+
+function getKnownCartLines(
+  cartItems: CartItem[],
+  catalog: Product[],
+): CartItem[] {
+  const catalogById = new Map(catalog.map((product) => [product.id, product]));
+
+  return cartItems
+    .filter((item) => catalogById.has(item.productId) && item.quantity > 0)
+    .map((item) => ({ ...item }))
+    .sort((first, second) => first.productId.localeCompare(second.productId));
+}
+
+function hashOrderInput(input: string): string {
+  let hash = 0;
+
+  for (const character of input) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return hash.toString(36).toUpperCase().padStart(7, "0");
+}
+
+export function validateCheckout(
+  details: CheckoutDetails,
+  cartItems: CartItem[],
+  catalog: Product[],
+): CheckoutValidationResult {
+  const normalizedDetails = normalizeCheckoutDetails(details);
+  const errors: CheckoutValidationResult["errors"] = {};
+
+  if (!normalizedDetails.name) {
+    errors.name = "Enter your name.";
+  }
+
+  if (!normalizedDetails.email) {
+    errors.email = "Enter your email.";
+  } else if (!hasValidEmailShape(normalizedDetails.email)) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  if (!normalizedDetails.shippingAddress) {
+    errors.shippingAddress = "Enter a shipping address.";
+  }
+
+  if (calculateCartTotal(cartItems, catalog).itemCount === 0) {
+    errors.cart = "Add at least one catalog item to checkout.";
+  }
+
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+}
+
+export function createOrderConfirmationId(
+  details: CheckoutDetails,
+  cartItems: CartItem[],
+  catalog: Product[],
+): string {
+  const normalizedDetails = normalizeCheckoutDetails(details);
+  const cartLines = getKnownCartLines(cartItems, catalog)
+    .map((item) => `${item.productId}:${item.quantity}`)
+    .join("|");
+  const totalCents = calculateCartTotal(cartItems, catalog).totalCents;
+  const orderInput = [
+    normalizedDetails.name,
+    normalizedDetails.email,
+    normalizedDetails.shippingAddress,
+    cartLines,
+    totalCents.toString(),
+  ].join("|");
+
+  return `X15-${hashOrderInput(orderInput)}`;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,10 +36,25 @@ button {
   border-radius: 6px;
   background: #1f6f63;
   color: #ffffff;
-  cursor: not-allowed;
+  cursor: pointer;
   font: inherit;
   font-weight: 700;
   padding: 0.75rem 1rem;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+input,
+textarea {
+  border: 1px solid #cfc7bc;
+  border-radius: 6px;
+  color: #1d252c;
+  font: inherit;
+  padding: 0.7rem 0.75rem;
+  width: 100%;
 }
 
 .site-header {
@@ -248,6 +263,109 @@ main {
   margin-bottom: 0.35rem;
 }
 
+.cart-list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.cart-line {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #ded8cf;
+  border-radius: 8px;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  padding: 0.85rem;
+}
+
+.cart-line span,
+.empty-cart,
+.field span,
+.field__error,
+.confirmation-panel span {
+  color: #4d5963;
+}
+
+.cart-line__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cart-line__actions button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.cart-line__actions input {
+  min-width: 4rem;
+  width: 4rem;
+}
+
+.totals-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.totals-list div {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.totals-list dt {
+  color: #4d5963;
+}
+
+.totals-list dd {
+  font-weight: 800;
+  margin: 0;
+}
+
+.totals-list__total {
+  border-top: 1px solid #edf0ee;
+  padding-top: 0.65rem;
+}
+
+.checkout-form {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field__error {
+  color: #a14f28;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.confirmation-panel {
+  background: #ffffff;
+  border: 1px solid #ded8cf;
+  border-radius: 8px;
+  min-width: 220px;
+  padding: 1rem;
+}
+
+.confirmation-panel strong {
+  color: #1f6f63;
+  display: block;
+  font-size: 1.2rem;
+  margin-top: 0.35rem;
+}
+
 @media (max-width: 640px) {
   .site-header__nav,
   .store-section--split {
@@ -265,5 +383,10 @@ main {
 
   .intro h1 {
     font-size: 2.45rem;
+  }
+
+  .cart-line {
+    align-items: stretch;
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Add a deterministic cart and checkout layer to the framework-free Vite storefront. The implementation keeps cart mutation, totals, checkout validation, and order confirmation IDs in pure helpers, then wires those helpers into the browser UI with in-memory state only.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/storefront.ts` | UPDATE | Added cart mutation helpers, subtotal/shipping/tax/total calculations, checkout validation, and deterministic order confirmation IDs. |
| `src/storefront.test.ts` | UPDATE | Added coverage for cart mutation, totals, unknown products, empty carts, checkout validation, and deterministic confirmation IDs. |
| `src/main.ts` | UPDATE | Added rendered cart rows, totals, checkout fields, validation errors, confirmation output, and guarded in-memory DOM behavior. |
| `src/main.test.ts` | UPDATE | Added render assertions for cart controls, empty cart, totals, checkout errors, and order confirmation output. |
| `src/styles.css` | UPDATE | Added styles for cart lines, totals, checkout fields, validation errors, and confirmation panel. |

## Tests

- `src/storefront.test.ts` - Covers price formatting, empty summaries, item aggregation, unknown product handling, immutable cart add/remove/update behavior, deterministic totals, checkout validation, valid checkout acceptance, and order confirmation ID stability.
- `src/main.test.ts` - Covers storefront shell output, product cards, empty cart rendering, populated cart totals, checkout validation errors, and confirmation rendering.

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] All tests pass (17 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

- Installed dependencies with `npm install` before validation because `node_modules` was missing locally. No tracked package files were modified.

### Issues Resolved

- Split subtotal/count reduction into an internal base summary type so the expanded `CartSummary` can include shipping, tax, and total fields without reducer type gaps.
- Ran Prettier on touched source files after TypeScript edits and reran validation successfully.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/75fc21ca59d1b2d83030942e1bba0040/plan.md`
**Workflow ID**: `75fc21ca59d1b2d83030942e1bba0040`
Fixes #57
