### PR TITLE
test: add Archon E2E self-merge marker

### DIFF
--- a/archon-e2e/2026-05-01T16-45-23-689Z-61.md
+++ b/archon-e2e/2026-05-01T16-45-23-689Z-61.md
@@ -1,0 +1,1 @@
+Archon E2E self-merge smoke test 2026-05-01T16-45-23-689Z issue 61 completed.


### PR DESCRIPTION
## Summary
- Adds one disposable Archon E2E self-merge marker file.
- Session: `2026-05-01T16-45-23-689Z`
- File: `archon-e2e/2026-05-01T16-45-23-689Z-61.md`

## Validation
- Created by `archon-e2e-tiny-self-merge`.
- Scoped to `archon-e2e`.

Closes #61