### PR TITLE
Ecommerce Catalog Interactions

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { createStorefrontMarkup, products } from "./main";
+import {
+  createStorefrontMarkup,
+  defaultCatalogState,
+  getCatalogProducts,
+  products,
+} from "./main";
 
 describe("createStorefrontMarkup", () => {
   it("renders the storefront header", () => {
@@ -36,5 +41,86 @@ describe("createStorefrontMarkup", () => {
     const markup = createStorefrontMarkup([]);
 
     expect(markup).toContain("Products will appear here soon.");
+  });
+
+  it("renders catalog controls", () => {
+    const markup = createStorefrontMarkup(products);
+
+    expect(markup).toContain("Search");
+    expect(markup).toContain('id="catalog-search"');
+    expect(markup).toContain("Category");
+    expect(markup).toContain('id="catalog-category"');
+    expect(markup).toContain("Price sort");
+    expect(markup).toContain('id="catalog-sort"');
+    expect(markup).toContain('value="price-asc"');
+    expect(markup).toContain('value="price-desc"');
+  });
+
+  it("renders an empty product state for filtered results", () => {
+    const markup = createStorefrontMarkup(products, {
+      ...defaultCatalogState,
+      search: "not in catalog",
+    });
+
+    expect(markup).toContain("Products will appear here soon.");
+  });
+});
+
+describe("getCatalogProducts", () => {
+  it("filters products by category", () => {
+    const catalogProducts = getCatalogProducts(products, {
+      ...defaultCatalogState,
+      category: "Kitchen",
+    });
+
+    expect(catalogProducts).toHaveLength(1);
+    expect(
+      catalogProducts.every((product) => product.category === "Kitchen"),
+    ).toBe(true);
+  });
+
+  it("searches products case-insensitively by partial text", () => {
+    const catalogProducts = getCatalogProducts(products, {
+      ...defaultCatalogState,
+      search: "LAMP",
+    });
+
+    expect(catalogProducts.map((product) => product.name)).toEqual([
+      "Desk Companion Lamp",
+    ]);
+  });
+
+  it("sorts products by price ascending", () => {
+    const catalogProducts = getCatalogProducts(products, {
+      ...defaultCatalogState,
+      sort: "price-asc",
+    });
+
+    expect(catalogProducts.map((product) => product.price)).toEqual([
+      48, 64, 72, 89,
+    ]);
+  });
+
+  it("sorts products by price descending", () => {
+    const catalogProducts = getCatalogProducts(products, {
+      ...defaultCatalogState,
+      sort: "price-desc",
+    });
+
+    expect(catalogProducts.map((product) => product.price)).toEqual([
+      89, 72, 64, 48,
+    ]);
+  });
+
+  it("combines category, search, and sort", () => {
+    const catalogProducts = getCatalogProducts(products, {
+      category: "Kitchen",
+      search: "coffee",
+      sort: "price-desc",
+    });
+
+    expect(catalogProducts.map((product) => product.name)).toEqual([
+      "Ceramic Pour-Over Set",
+    ]);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,20 @@ export type Product = {
   description: string;
 };
 
+export type PriceSort = "none" | "price-asc" | "price-desc";
+
+export type CatalogState = {
+  category: string;
+  search: string;
+  sort: PriceSort;
+};
+
+export const defaultCatalogState: CatalogState = {
+  category: "All",
+  search: "",
+  sort: "none",
+};
+
 export const products: Product[] = [
   {
     name: "Everyday Tote",
@@ -43,6 +57,86 @@ const formatPrice = (price: number): string =>
     maximumFractionDigits: 0,
   }).format(price);
 
+const escapeAttribute = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+const isPriceSort = (value: string): value is PriceSort =>
+  value === "none" || value === "price-asc" || value === "price-desc";
+
+export const getCatalogProducts = (
+  items: Product[],
+  state: CatalogState,
+): Product[] => {
+  const search = state.search.trim().toLowerCase();
+  const filteredProducts = items.filter((product) => {
+    const matchesCategory =
+      state.category === "All" || product.category === state.category;
+    const matchesSearch =
+      search.length === 0 ||
+      [product.name, product.category, product.description].some((value) =>
+        value.toLowerCase().includes(search),
+      );
+
+    return matchesCategory && matchesSearch;
+  });
+
+  if (state.sort === "price-asc") {
+    return [...filteredProducts].sort((a, b) => a.price - b.price);
+  }
+
+  if (state.sort === "price-desc") {
+    return [...filteredProducts].sort((a, b) => b.price - a.price);
+  }
+
+  return filteredProducts;
+};
+
+const createCatalogControls = (
+  state: CatalogState,
+  categories: string[],
+): string => `
+  <div class="catalog-controls" aria-label="Catalog controls">
+    <div class="catalog-field">
+      <label for="catalog-search">Search</label>
+      <input
+        id="catalog-search"
+        name="search"
+        type="search"
+        value="${escapeAttribute(state.search)}"
+        placeholder="Product or category"
+      />
+    </div>
+
+    <div class="catalog-field">
+      <label for="catalog-category">Category</label>
+      <select id="catalog-category" name="category">
+        ${categories
+          .map(
+            (category) => `
+              <option value="${escapeAttribute(category)}"${
+                category === state.category ? " selected" : ""
+              }>${category}</option>
+            `,
+          )
+          .join("")}
+      </select>
+    </div>
+
+    <div class="catalog-field">
+      <label for="catalog-sort">Price sort</label>
+      <select id="catalog-sort" name="sort">
+        <option value="none"${state.sort === "none" ? " selected" : ""}>Featured</option>
+        <option value="price-asc"${state.sort === "price-asc" ? " selected" : ""}>Low to high</option>
+        <option value="price-desc"${state.sort === "price-desc" ? " selected" : ""}>High to low</option>
+      </select>
+    </div>
+  </div>
+`;
+
 const createProductCards = (items: Product[]): string => {
   if (items.length === 0) {
     return '<p class="empty-products">Products will appear here soon.</p>';
@@ -64,7 +158,17 @@ const createProductCards = (items: Product[]): string => {
     .join("");
 };
 
-export const createStorefrontMarkup = (items: Product[] = products): string => `
+export const createStorefrontMarkup = (
+  items: Product[] = products,
+  state: CatalogState = defaultCatalogState,
+): string => {
+  const categories = [
+    "All",
+    ...Array.from(new Set(items.map((product) => product.category))),
+  ];
+  const catalogProducts = getCatalogProducts(items, state);
+
+  return `
   <header class="store-header">
     <div>
       <p class="eyebrow">X15 Store</p>
@@ -79,8 +183,9 @@ export const createStorefrontMarkup = (items: Product[] = products): string => `
         <p class="eyebrow">Catalog</p>
         <h2 id="products-heading">Featured products</h2>
       </div>
+      ${createCatalogControls(state, categories)}
       <div class="product-grid">
-        ${createProductCards(items)}
+        ${createProductCards(catalogProducts)}
       </div>
     </section>
 
@@ -99,12 +204,42 @@ export const createStorefrontMarkup = (items: Product[] = products): string => `
     </aside>
   </main>
 `;
+};
 
 export const renderStorefront = (
   root: HTMLElement,
   items: Product[] = products,
 ): void => {
-  root.innerHTML = createStorefrontMarkup(items);
+  let state: CatalogState = { ...defaultCatalogState };
+
+  const renderWithState = (): void => {
+    root.innerHTML = createStorefrontMarkup(items, state);
+
+    const searchInput = root.querySelector<HTMLInputElement>("#catalog-search");
+    const categorySelect =
+      root.querySelector<HTMLSelectElement>("#catalog-category");
+    const sortSelect = root.querySelector<HTMLSelectElement>("#catalog-sort");
+
+    searchInput?.addEventListener("input", () => {
+      state = { ...state, search: searchInput.value };
+      renderWithState();
+    });
+
+    categorySelect?.addEventListener("change", () => {
+      state = { ...state, category: categorySelect.value };
+      renderWithState();
+    });
+
+    sortSelect?.addEventListener("change", () => {
+      state = {
+        ...state,
+        sort: isPriceSort(sortSelect.value) ? sortSelect.value : "none",
+      };
+      renderWithState();
+    });
+  };
+
+  renderWithState();
 };
 
 if (typeof document !== "undefined") {

--- a/src/styles.css
+++ b/src/styles.css
@@ -96,6 +96,46 @@ select {
   font-size: 1.5rem;
 }
 
+.catalog-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.5fr) repeat(2, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 16px;
+  border: 1px solid #d8d0c2;
+  border-radius: 8px;
+  background: #fffaf0;
+}
+
+.catalog-field {
+  display: grid;
+  gap: 6px;
+}
+
+.catalog-field label {
+  color: #50574f;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.catalog-field input,
+.catalog-field select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid #d8d0c2;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #1f2520;
+}
+
+.catalog-field input {
+  padding: 9px 11px;
+}
+
+.catalog-field select {
+  padding: 9px 10px;
+}
+
 .product-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -178,6 +218,10 @@ select {
 
   .store-layout,
   .product-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-controls {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

Add small, real catalog browsing behavior to the existing Vite TypeScript storefront skeleton. This keeps the current string-rendered storefront shape while adding category filtering, text search, price sorting, UI controls, DOM event wiring, and focused Vitest coverage.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/main.ts` | UPDATE | Added catalog state/types, pure filtering and sorting helpers, escaped control rendering, filtered product rendering, and DOM event wiring for search/category/sort controls. |
| `src/styles.css` | UPDATE | Added compact responsive catalog control styling that matches the existing storefront visual system. |
| `src/main.test.ts` | UPDATE | Added focused tests for catalog controls, empty filtered state, category filtering, case-insensitive search, ascending/descending price sort, and combined filtering/sorting. |

## Tests

- `src/main.test.ts` - Added tests for `renders catalog controls`, `renders an empty product state for filtered results`, `filters products by category`, `searches products case-insensitively by partial text`, `sorts products by price ascending`, `sorts products by price descending`, and `combines category, search, and sort`.

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] All tests pass (11 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

No deviations. Implementation matched the plan exactly.

### Issues Resolved

- `npm run format:check` initially reported Prettier style issues in touched TypeScript files. Ran Prettier on the touched files and reran validation successfully.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/1fa4a9db8ef5a70c52a191e58798c9b2/plan.md`
**Workflow ID**: `1fa4a9db8ef5a70c52a191e58798c9b2`
Fixes #66
