### PR TITLE
Ecommerce Cart And Checkout

### DIFF
--- a/src/cart.test.ts
+++ b/src/cart.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addCartItem,
+  calculateCartSummary,
+  calculateOrderTotal,
+  calculateShipping,
+  calculateSubtotal,
+  calculateTax,
+  removeCartItem,
+  updateCartItemQuantity,
+  type CartLine,
+} from "./cart";
+
+const sampleCatalog = [
+  { id: "sample", price: 12.5 },
+  { id: "special", price: 8 },
+  { id: "premium", price: 120 },
+];
+
+describe("cart helpers", () => {
+  it("adds a new product as one line with quantity one", () => {
+    expect(addCartItem([], "sample")).toEqual([
+      { productId: "sample", quantity: 1 },
+    ]);
+  });
+
+  it("increments quantity when adding an existing product", () => {
+    expect(
+      addCartItem([{ productId: "sample", quantity: 1 }], "sample"),
+    ).toEqual([{ productId: "sample", quantity: 2 }]);
+  });
+
+  it("removes only the requested product", () => {
+    const cart: CartLine[] = [
+      { productId: "sample", quantity: 1 },
+      { productId: "special", quantity: 2 },
+    ];
+
+    expect(removeCartItem(cart, "sample")).toEqual([
+      { productId: "special", quantity: 2 },
+    ]);
+  });
+
+  it("updates quantity and removes the line when quantity is zero", () => {
+    const cart: CartLine[] = [{ productId: "sample", quantity: 1 }];
+
+    expect(updateCartItemQuantity(cart, "sample", 2.9)).toEqual([
+      { productId: "sample", quantity: 2 },
+    ]);
+    expect(updateCartItemQuantity(cart, "sample", 0)).toEqual([]);
+  });
+
+  it("multiplies product price by quantity for the subtotal", () => {
+    expect(
+      calculateSubtotal(
+        [
+          { productId: "sample", quantity: 2 },
+          { productId: "special", quantity: 1 },
+        ],
+        sampleCatalog,
+      ),
+    ).toBe(33);
+  });
+
+  it("ignores unknown product ids in the subtotal", () => {
+    expect(
+      calculateSubtotal(
+        [
+          { productId: "sample", quantity: 1 },
+          { productId: "missing", quantity: 4 },
+        ],
+        sampleCatalog,
+      ),
+    ).toBe(12.5);
+  });
+
+  it("calculates deterministic shipping tiers", () => {
+    expect(calculateShipping(0)).toBe(0);
+    expect(calculateShipping(99.99)).toBe(7.5);
+    expect(calculateShipping(100)).toBe(0);
+  });
+
+  it("rounds tax and total to cents", () => {
+    expect(calculateTax(20.555)).toBe(1.64);
+    expect(calculateOrderTotal(20.555, 7.5, 1.6444)).toBe(29.7);
+  });
+
+  it("derives complete cart summary totals", () => {
+    expect(
+      calculateCartSummary(
+        [
+          { productId: "sample", quantity: 2 },
+          { productId: "missing", quantity: 5 },
+        ],
+        sampleCatalog,
+      ),
+    ).toEqual({
+      itemCount: 7,
+      subtotal: 25,
+      shipping: 7.5,
+      tax: 2,
+      total: 34.5,
+    });
+  });
+});

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -1,0 +1,115 @@
+export type CartLine = {
+  productId: string;
+  quantity: number;
+};
+
+export type CartSummary = {
+  itemCount: number;
+  subtotal: number;
+  shipping: number;
+  tax: number;
+  total: number;
+};
+
+type PricedProduct = {
+  id: string;
+  price: number;
+};
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export const addCartItem = (
+  cart: CartLine[],
+  productId: string,
+): CartLine[] => {
+  const existingLine = cart.find((line) => line.productId === productId);
+
+  if (!existingLine) {
+    return [...cart, { productId, quantity: 1 }];
+  }
+
+  return cart.map((line) =>
+    line.productId === productId
+      ? { ...line, quantity: line.quantity + 1 }
+      : line,
+  );
+};
+
+export const removeCartItem = (
+  cart: CartLine[],
+  productId: string,
+): CartLine[] => cart.filter((line) => line.productId !== productId);
+
+export const updateCartItemQuantity = (
+  cart: CartLine[],
+  productId: string,
+  quantity: number,
+): CartLine[] => {
+  const normalizedQuantity = Math.floor(quantity);
+
+  if (normalizedQuantity <= 0) {
+    return removeCartItem(cart, productId);
+  }
+
+  const existingLine = cart.find((line) => line.productId === productId);
+
+  if (!existingLine) {
+    return [...cart, { productId, quantity: normalizedQuantity }];
+  }
+
+  return cart.map((line) =>
+    line.productId === productId
+      ? { ...line, quantity: normalizedQuantity }
+      : line,
+  );
+};
+
+export const calculateSubtotal = (
+  cart: CartLine[],
+  catalog: PricedProduct[],
+): number =>
+  roundToCents(
+    cart.reduce((subtotal, line) => {
+      const product = catalog.find((item) => item.id === line.productId);
+
+      if (!product) {
+        return subtotal;
+      }
+
+      return subtotal + product.price * line.quantity;
+    }, 0),
+  );
+
+export const calculateShipping = (subtotal: number): number => {
+  if (subtotal === 0 || subtotal >= 100) {
+    return 0;
+  }
+
+  return 7.5;
+};
+
+export const calculateTax = (subtotal: number): number =>
+  roundToCents(subtotal * 0.08);
+
+export const calculateOrderTotal = (
+  subtotal: number,
+  shipping: number,
+  tax: number,
+): number => roundToCents(subtotal + shipping + tax);
+
+export const calculateCartSummary = (
+  cart: CartLine[],
+  catalog: PricedProduct[],
+): CartSummary => {
+  const subtotal = calculateSubtotal(cart, catalog);
+  const shipping = calculateShipping(subtotal);
+  const tax = calculateTax(subtotal);
+
+  return {
+    itemCount: cart.reduce((count, line) => count + line.quantity, 0),
+    subtotal,
+    shipping,
+    tax,
+    total: calculateOrderTotal(subtotal, shipping, tax),
+  };
+};

--- a/src/checkout.test.ts
+++ b/src/checkout.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { CartLine } from "./cart";
+import {
+  createOrderConfirmationId,
+  validateCheckout,
+  type CheckoutDetails,
+} from "./checkout";
+
+const validDetails: CheckoutDetails = {
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  shippingAddress: "12 Engine Way",
+};
+
+const cart: CartLine[] = [
+  { productId: "sample", quantity: 2 },
+  { productId: "special", quantity: 1 },
+];
+
+describe("checkout helpers", () => {
+  it("returns a name error when name is missing", () => {
+    expect(validateCheckout({ ...validDetails, name: " " }).errors.name).toBe(
+      "Name is required.",
+    );
+  });
+
+  it("returns an email error when email is missing or malformed", () => {
+    expect(validateCheckout({ ...validDetails, email: "" }).errors.email).toBe(
+      "Email is required.",
+    );
+    expect(
+      validateCheckout({ ...validDetails, email: "ada.example.com" }).errors
+        .email,
+    ).toBe("Enter a valid email address.");
+  });
+
+  it("returns a shipping address error when address is missing", () => {
+    expect(
+      validateCheckout({ ...validDetails, shippingAddress: " " }).errors
+        .shippingAddress,
+    ).toBe("Shipping address is required.");
+  });
+
+  it("returns a valid result for complete details", () => {
+    expect(validateCheckout(validDetails)).toEqual({
+      isValid: true,
+      errors: {},
+    });
+  });
+
+  it("creates a stable confirmation id for repeated calls", () => {
+    expect(createOrderConfirmationId(cart, validDetails)).toBe(
+      createOrderConfirmationId(cart, validDetails),
+    );
+  });
+
+  it("creates the same confirmation id when cart lines are reordered", () => {
+    expect(createOrderConfirmationId(cart, validDetails)).toBe(
+      createOrderConfirmationId([...cart].reverse(), validDetails),
+    );
+  });
+
+  it("changes confirmation id when cart contents or email meaning changes", () => {
+    const baseId = createOrderConfirmationId(cart, validDetails);
+
+    expect(
+      createOrderConfirmationId(
+        [{ productId: "sample", quantity: 3 }],
+        validDetails,
+      ),
+    ).not.toBe(baseId);
+    expect(
+      createOrderConfirmationId(cart, {
+        ...validDetails,
+        email: "other@example.com",
+      }),
+    ).not.toBe(baseId);
+  });
+
+  it("normalizes surrounding whitespace and email casing for ids", () => {
+    expect(createOrderConfirmationId(cart, validDetails)).toBe(
+      createOrderConfirmationId(cart, {
+        name: " Ada Lovelace ",
+        email: " ADA@EXAMPLE.COM ",
+        shippingAddress: " 12 Engine Way ",
+      }),
+    );
+  });
+});

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -1,0 +1,72 @@
+import type { CartLine } from "./cart";
+
+export type CheckoutDetails = {
+  name: string;
+  email: string;
+  shippingAddress: string;
+};
+
+export type CheckoutErrors = Partial<Record<keyof CheckoutDetails, string>>;
+
+export type CheckoutValidationResult = {
+  isValid: boolean;
+  errors: CheckoutErrors;
+};
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const normalizeDetails = (details: CheckoutDetails): CheckoutDetails => ({
+  name: details.name.trim(),
+  email: details.email.trim().toLowerCase(),
+  shippingAddress: details.shippingAddress.trim(),
+});
+
+export const validateCheckout = (
+  details: CheckoutDetails,
+): CheckoutValidationResult => {
+  const normalizedDetails = normalizeDetails(details);
+  const errors: CheckoutErrors = {};
+
+  if (!normalizedDetails.name) {
+    errors.name = "Name is required.";
+  }
+
+  if (!normalizedDetails.email) {
+    errors.email = "Email is required.";
+  } else if (!emailPattern.test(normalizedDetails.email)) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  if (!normalizedDetails.shippingAddress) {
+    errors.shippingAddress = "Shipping address is required.";
+  }
+
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+};
+
+export const createOrderConfirmationId = (
+  cart: CartLine[],
+  details: CheckoutDetails,
+): string => {
+  const normalizedDetails = normalizeDetails(details);
+  const normalizedCart = [...cart]
+    .sort((left, right) => left.productId.localeCompare(right.productId))
+    .map((line) => `${line.productId}:${line.quantity}`)
+    .join("|");
+  const source = [
+    normalizedDetails.name,
+    normalizedDetails.email,
+    normalizedDetails.shippingAddress,
+    normalizedCart,
+  ].join("::");
+  const hash = [...source].reduce(
+    (accumulator, character) =>
+      (accumulator * 31 + character.charCodeAt(0)) >>> 0,
+    0,
+  );
+
+  return `X15-${hash.toString(36).toUpperCase().padStart(7, "0")}`;
+};

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -31,18 +31,31 @@ describe("storefront helpers", () => {
   });
 
   it("returns zero values for an empty cart", () => {
-    expect(calculateCartSummary([])).toEqual({
+    expect(calculateCartSummary([], sampleProducts)).toEqual({
       itemCount: 0,
       subtotal: 0,
+      shipping: 0,
+      tax: 0,
+      total: 0,
     });
   });
 
   it("totals selected product ids and ignores unknown ids", () => {
     expect(
-      calculateCartSummary(["sample", "missing", "special"], sampleProducts),
+      calculateCartSummary(
+        [
+          { productId: "sample", quantity: 1 },
+          { productId: "missing", quantity: 3 },
+          { productId: "special", quantity: 1 },
+        ],
+        sampleProducts,
+      ),
     ).toEqual({
-      itemCount: 2,
+      itemCount: 5,
       subtotal: 20.5,
+      shipping: 7.5,
+      tax: 1.64,
+      total: 29.64,
     });
   });
 
@@ -52,7 +65,7 @@ describe("storefront helpers", () => {
     expect(markup).toContain("X15 Storefront");
     expect(markup).toContain("product-grid");
     expect(markup).toContain("Cart summary");
-    expect(markup).toContain("Checkout placeholder");
+    expect(markup).toContain("Shipping details");
   });
 
   it("renders every product card name", () => {
@@ -63,17 +76,20 @@ describe("storefront helpers", () => {
     }
   });
 
-  it("includes cart summary and checkout placeholders", () => {
-    const markup = createStorefrontMarkup(sampleProducts, {
-      itemCount: 2,
-      subtotal: 20.5,
-    });
+  it("includes cart totals and checkout controls", () => {
+    const markup = createStorefrontMarkup(
+      sampleProducts,
+      calculateCartSummary(
+        [{ productId: "sample", quantity: 2 }],
+        sampleProducts,
+      ),
+      [{ productId: "sample", quantity: 2 }],
+    );
 
     expect(markup).toContain("data-cart-summary");
-    expect(markup).toContain("2 items selected, $20.50 subtotal");
-    expect(markup).toContain(
-      "Shipping, payment, and order review steps will appear here",
-    );
+    expect(markup).toContain("<dd>$25.00</dd>");
+    expect(markup).toContain('data-cart-quantity-id="sample"');
+    expect(markup).toContain("data-checkout-form");
   });
 
   it("renders a stable empty catalog state", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,26 @@
 import "./styles.css";
 
+import {
+  addCartItem,
+  calculateCartSummary as calculateCartSummaryForCart,
+  removeCartItem,
+  updateCartItemQuantity,
+  type CartLine,
+  type CartSummary,
+} from "./cart";
+import {
+  createOrderConfirmationId,
+  validateCheckout,
+  type CheckoutDetails,
+  type CheckoutErrors,
+} from "./checkout";
+
 export type Product = {
   id: string;
   name: string;
   description: string;
   price: number;
   category: string;
-};
-
-export type CartSummary = {
-  itemCount: number;
-  subtotal: number;
 };
 
 export const products: Product[] = [
@@ -52,25 +62,8 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 export const formatPrice = (price: number): string =>
   currencyFormatter.format(price);
 
-export const calculateCartSummary = (
-  selectedProductIds: string[],
-  catalog: Product[] = products,
-): CartSummary =>
-  selectedProductIds.reduce<CartSummary>(
-    (summary, productId) => {
-      const product = catalog.find((item) => item.id === productId);
-
-      if (!product) {
-        return summary;
-      }
-
-      return {
-        itemCount: summary.itemCount + 1,
-        subtotal: summary.subtotal + product.price,
-      };
-    },
-    { itemCount: 0, subtotal: 0 },
-  );
+export { calculateCartSummaryForCart as calculateCartSummary };
+export type { CartLine, CartSummary } from "./cart";
 
 const escapeHtml = (value: string): string =>
   value
@@ -106,9 +99,178 @@ const createProductCards = (catalog: Product[]): string => {
     .join("");
 };
 
+type CheckoutState = {
+  details: CheckoutDetails;
+  errors: CheckoutErrors;
+  cartError: string;
+  confirmationId: string;
+};
+
+const emptyCheckoutDetails: CheckoutDetails = {
+  name: "",
+  email: "",
+  shippingAddress: "",
+};
+
+const createEmptyCheckoutState = (): CheckoutState => ({
+  details: { ...emptyCheckoutDetails },
+  errors: {},
+  cartError: "",
+  confirmationId: "",
+});
+
+const createCartLinesMarkup = (
+  catalog: Product[],
+  cart: CartLine[],
+): string => {
+  if (cart.length === 0) {
+    return `<p class="muted" data-cart-empty>Your cart is empty.</p>`;
+  }
+
+  return `
+    <div class="cart-lines">
+      ${cart
+        .map((line) => {
+          const product = catalog.find((item) => item.id === line.productId);
+
+          if (!product) {
+            return "";
+          }
+
+          return `
+            <article class="cart-line" data-cart-line>
+              <div>
+                <h3>${escapeHtml(product.name)}</h3>
+                <p>${formatPrice(product.price)} each</p>
+              </div>
+              <div class="cart-line__controls">
+                <label>
+                  Qty
+                  <input
+                    type="number"
+                    min="0"
+                    step="1"
+                    value="${line.quantity}"
+                    data-cart-quantity-id="${escapeHtml(line.productId)}"
+                    aria-label="${escapeHtml(product.name)} quantity"
+                  />
+                </label>
+                <button type="button" data-cart-decrement-id="${escapeHtml(line.productId)}">
+                  -
+                </button>
+                <button type="button" data-cart-increment-id="${escapeHtml(line.productId)}">
+                  +
+                </button>
+                <button type="button" data-cart-remove-id="${escapeHtml(line.productId)}">
+                  Remove
+                </button>
+              </div>
+              <strong>${formatPrice(product.price * line.quantity)}</strong>
+            </article>
+          `;
+        })
+        .join("")}
+    </div>
+  `;
+};
+
+const createCartTotalsMarkup = (cartSummary: CartSummary): string => `
+  <dl class="cart-totals" data-cart-summary>
+    <div>
+      <dt>Items</dt>
+      <dd>${cartSummary.itemCount}</dd>
+    </div>
+    <div>
+      <dt>Subtotal</dt>
+      <dd>${formatPrice(cartSummary.subtotal)}</dd>
+    </div>
+    <div>
+      <dt>Shipping</dt>
+      <dd>${formatPrice(cartSummary.shipping)}</dd>
+    </div>
+    <div>
+      <dt>Tax</dt>
+      <dd>${formatPrice(cartSummary.tax)}</dd>
+    </div>
+    <div class="cart-totals__total">
+      <dt>Total</dt>
+      <dd>${formatPrice(cartSummary.total)}</dd>
+    </div>
+  </dl>
+`;
+
+const createCheckoutErrorMarkup = (
+  id: string,
+  error: string | undefined,
+): string =>
+  error
+    ? `<p class="field-error" id="${id}" role="alert">${escapeHtml(error)}</p>`
+    : "";
+
+const createCheckoutMarkup = (checkoutState: CheckoutState): string => {
+  const nameErrorId = "checkout-name-error";
+  const emailErrorId = "checkout-email-error";
+  const addressErrorId = "checkout-address-error";
+
+  return `
+    ${
+      checkoutState.confirmationId
+        ? `<p class="checkout-confirmation" data-checkout-confirmation>
+            Order confirmed: ${escapeHtml(checkoutState.confirmationId)}
+          </p>`
+        : ""
+    }
+    ${
+      checkoutState.cartError
+        ? `<p class="field-error" role="alert">${escapeHtml(checkoutState.cartError)}</p>`
+        : ""
+    }
+    <form class="checkout-form" data-checkout-form>
+      <label>
+        Name
+        <input
+          type="text"
+          name="name"
+          value="${escapeHtml(checkoutState.details.name)}"
+          data-checkout-name
+          ${checkoutState.errors.name ? `aria-describedby="${nameErrorId}"` : ""}
+        />
+      </label>
+      ${createCheckoutErrorMarkup(nameErrorId, checkoutState.errors.name)}
+      <label>
+        Email
+        <input
+          type="email"
+          name="email"
+          value="${escapeHtml(checkoutState.details.email)}"
+          data-checkout-email
+          ${checkoutState.errors.email ? `aria-describedby="${emailErrorId}"` : ""}
+        />
+      </label>
+      ${createCheckoutErrorMarkup(emailErrorId, checkoutState.errors.email)}
+      <label>
+        Shipping address
+        <textarea
+          name="shippingAddress"
+          rows="3"
+          data-checkout-address
+          ${checkoutState.errors.shippingAddress ? `aria-describedby="${addressErrorId}"` : ""}
+        >${escapeHtml(checkoutState.details.shippingAddress)}</textarea>
+      </label>
+      ${createCheckoutErrorMarkup(
+        addressErrorId,
+        checkoutState.errors.shippingAddress,
+      )}
+      <button type="submit">Confirm order</button>
+    </form>
+  `;
+};
+
 export const createStorefrontMarkup = (
   catalog: Product[] = products,
-  cartSummary: CartSummary = { itemCount: 0, subtotal: 0 },
+  cartSummary: CartSummary = calculateCartSummaryForCart([], catalog),
+  cart: CartLine[] = [],
+  checkoutState: CheckoutState = createEmptyCheckoutState(),
 ): string => `
   <header class="store-header">
     <div>
@@ -139,47 +301,32 @@ export const createStorefrontMarkup = (
     <aside class="cart-panel" id="cart" aria-labelledby="cart-title">
       <p class="eyebrow">Cart</p>
       <h2 id="cart-title">Cart summary</h2>
-      <p data-cart-summary>
-        ${cartSummary.itemCount} items selected, ${formatPrice(cartSummary.subtotal)} subtotal
-      </p>
-      <p class="muted">Cart persistence and line-item editing will be added later.</p>
+      ${createCartLinesMarkup(catalog, cart)}
+      ${createCartTotalsMarkup(cartSummary)}
     </aside>
 
     <section class="checkout-panel" id="checkout" aria-labelledby="checkout-title">
       <p class="eyebrow">Checkout</p>
-      <h2 id="checkout-title">Checkout placeholder</h2>
-      <p>
-        Shipping, payment, and order review steps will appear here in a future iteration.
-      </p>
+      <h2 id="checkout-title">Shipping details</h2>
+      ${createCheckoutMarkup(checkoutState)}
     </section>
   </main>
 `;
 
-const updateCartSummary = (selectedProductIds: string[]): void => {
-  const summary = calculateCartSummary(selectedProductIds);
-  const countElement = document.querySelector<HTMLElement>("[data-cart-count]");
-  const summaryElement = document.querySelector<HTMLElement>(
-    "[data-cart-summary]",
-  );
-
-  if (countElement) {
-    countElement.textContent = String(summary.itemCount);
-  }
-
-  if (summaryElement) {
-    summaryElement.textContent = `${summary.itemCount} items selected, ${formatPrice(
-      summary.subtotal,
-    )} subtotal`;
-  }
-};
-
 export const mountStorefront = (root: HTMLElement): void => {
-  const selectedProductIds: string[] = [];
+  let cart: CartLine[] = [];
+  let checkoutState = createEmptyCheckoutState();
 
-  root.innerHTML = createStorefrontMarkup(
-    products,
-    calculateCartSummary(selectedProductIds),
-  );
+  const render = (): void => {
+    root.innerHTML = createStorefrontMarkup(
+      products,
+      calculateCartSummaryForCart(cart, products),
+      cart,
+      checkoutState,
+    );
+  };
+
+  render();
 
   root.addEventListener("click", (event) => {
     const target = event.target;
@@ -188,22 +335,139 @@ export const mountStorefront = (root: HTMLElement): void => {
       return;
     }
 
-    const button = target.closest<HTMLButtonElement>("[data-product-id]");
+    const addButton = target.closest<HTMLButtonElement>("[data-product-id]");
 
-    if (!button) {
+    if (addButton) {
+      const product = products.find(
+        (item) => item.id === addButton.dataset.productId,
+      );
+
+      if (!product) {
+        return;
+      }
+
+      cart = addCartItem(cart, product.id);
+      checkoutState = { ...checkoutState, cartError: "", confirmationId: "" };
+      render();
       return;
     }
 
-    const product = products.find(
-      (item) => item.id === button.dataset.productId,
+    const removeButton = target.closest<HTMLButtonElement>(
+      "[data-cart-remove-id]",
     );
 
-    if (!product) {
+    if (removeButton?.dataset.cartRemoveId) {
+      cart = removeCartItem(cart, removeButton.dataset.cartRemoveId);
+      checkoutState = { ...checkoutState, confirmationId: "" };
+      render();
       return;
     }
 
-    selectedProductIds.push(product.id);
-    updateCartSummary(selectedProductIds);
+    const decrementButton = target.closest<HTMLButtonElement>(
+      "[data-cart-decrement-id]",
+    );
+
+    if (decrementButton?.dataset.cartDecrementId) {
+      const line = cart.find(
+        (item) => item.productId === decrementButton.dataset.cartDecrementId,
+      );
+
+      if (!line) {
+        return;
+      }
+
+      cart = updateCartItemQuantity(cart, line.productId, line.quantity - 1);
+      checkoutState = { ...checkoutState, confirmationId: "" };
+      render();
+      return;
+    }
+
+    const incrementButton = target.closest<HTMLButtonElement>(
+      "[data-cart-increment-id]",
+    );
+
+    if (incrementButton?.dataset.cartIncrementId) {
+      cart = addCartItem(cart, incrementButton.dataset.cartIncrementId);
+      checkoutState = { ...checkoutState, confirmationId: "" };
+      render();
+    }
+  });
+
+  root.addEventListener("change", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    if (!target.dataset.cartQuantityId) {
+      return;
+    }
+
+    cart = updateCartItemQuantity(
+      cart,
+      target.dataset.cartQuantityId,
+      Number(target.value),
+    );
+    checkoutState = { ...checkoutState, confirmationId: "" };
+    render();
+  });
+
+  root.addEventListener("submit", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof HTMLFormElement)) {
+      return;
+    }
+
+    if (!target.matches("[data-checkout-form]")) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const details: CheckoutDetails = {
+      name:
+        target.querySelector<HTMLInputElement>("[data-checkout-name]")?.value ??
+        "",
+      email:
+        target.querySelector<HTMLInputElement>("[data-checkout-email]")
+          ?.value ?? "",
+      shippingAddress:
+        target.querySelector<HTMLTextAreaElement>("[data-checkout-address]")
+          ?.value ?? "",
+    };
+    const validation = validateCheckout(details);
+
+    if (cart.length === 0) {
+      checkoutState = {
+        details,
+        errors: validation.errors,
+        cartError: "Add at least one item before checkout.",
+        confirmationId: "",
+      };
+      render();
+      return;
+    }
+
+    if (!validation.isValid) {
+      checkoutState = {
+        details,
+        errors: validation.errors,
+        cartError: "",
+        confirmationId: "",
+      };
+      render();
+      return;
+    }
+
+    checkoutState = {
+      details,
+      errors: {},
+      cartError: "",
+      confirmationId: createOrderConfirmationId(cart, details),
+    };
+    render();
   });
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,9 @@ body {
 }
 
 button,
-a {
+a,
+input,
+textarea {
   font: inherit;
 }
 
@@ -33,7 +35,9 @@ a {
 }
 
 button:focus-visible,
-a:focus-visible {
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
   outline: 3px solid #2563eb;
   outline-offset: 3px;
 }
@@ -198,6 +202,132 @@ a:focus-visible {
 .cart-panel p,
 .checkout-panel p {
   margin: 0.5rem 0 0;
+}
+
+.cart-lines {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.cart-line {
+  border: 1px solid #d8ded2;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.cart-line h3 {
+  font-size: 1rem;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.cart-line p {
+  color: #5d6b5f;
+  margin: 0.15rem 0 0;
+}
+
+.cart-line__controls {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cart-line__controls label,
+.checkout-form label {
+  color: #3f4c42;
+  display: grid;
+  font-size: 0.86rem;
+  font-weight: 800;
+  gap: 0.35rem;
+}
+
+.cart-line__controls input {
+  max-width: 4.75rem;
+}
+
+.cart-line__controls button,
+.checkout-form button {
+  background: #2f5c45;
+  border: 0;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+  min-height: 2.35rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.cart-line__controls button:hover,
+.checkout-form button:hover {
+  background: #244936;
+}
+
+.cart-totals {
+  border-top: 1px solid #d8ded2;
+  display: grid;
+  gap: 0.45rem;
+  margin: 1rem 0 0;
+  padding-top: 1rem;
+}
+
+.cart-totals div {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.cart-totals dt,
+.cart-totals dd {
+  margin: 0;
+}
+
+.cart-totals dd {
+  font-weight: 800;
+}
+
+.cart-totals__total {
+  border-top: 1px solid #d8ded2;
+  font-size: 1.08rem;
+  margin-top: 0.25rem;
+  padding-top: 0.55rem;
+}
+
+.checkout-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.checkout-form input,
+.checkout-form textarea,
+.cart-line__controls input {
+  border: 1px solid #a9b5a6;
+  border-radius: 6px;
+  color: #18201b;
+  padding: 0.55rem 0.65rem;
+}
+
+.checkout-form textarea {
+  resize: vertical;
+}
+
+.field-error {
+  color: #b42318;
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.checkout-confirmation {
+  background: #edf7ef;
+  border: 1px solid #94c79c;
+  border-radius: 8px;
+  color: #244936;
+  font-weight: 800;
+  padding: 0.75rem;
 }
 
 .muted,


### PR DESCRIPTION
## Summary

Add a small, deterministic cart and checkout layer to the existing vanilla TypeScript storefront. Business logic is kept in pure helper modules, with the current string-template UI and event delegation updated to support cart editing, checkout validation, and order confirmation.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/cart.ts` | CREATE | Adds immutable cart add, remove, quantity update, subtotal, shipping, tax, and total helpers. |
| `src/cart.test.ts` | CREATE | Adds focused tests for cart mutations, summaries, unknown product handling, shipping tiers, tax, and totals. |
| `src/checkout.ts` | CREATE | Adds checkout detail validation and deterministic order confirmation id generation. |
| `src/checkout.test.ts` | CREATE | Adds focused tests for required fields, email validation, stable ids, cart order independence, and normalized inputs. |
| `src/main.ts` | UPDATE | Wires cart line rendering, quantity controls, remove behavior, totals, checkout validation, and confirmation state into the storefront. |
| `src/main.test.ts` | UPDATE | Updates storefront helper and markup assertions for the new cart summary and checkout UI. |
| `src/styles.css` | UPDATE | Adds compact cart, totals, checkout form, validation, and confirmation styles. |

## Tests

- `src/cart.test.ts` - 9 focused cart tests.
- `src/checkout.test.ts` - 8 focused checkout tests.
- `src/main.test.ts` - updated cart summary and checkout markup assertions.

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] All tests pass (25 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

- `src/main.test.ts` was updated immediately after `src/main.ts` because type-checking failed while tests still used the old selected-product-id summary signature.

### Issues Resolved

- `npm run format:check` initially reported Prettier drift in `src/cart.test.ts`, `src/main.test.ts`, and `src/main.ts`; those files were formatted and the full validation stack passed afterward.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/90d4ac7caf98b0a54e3ada7753a42dba/plan.md`
**Workflow ID**: `90d4ac7caf98b0a54e3ada7753a42dba`

Fixes #105
