### PR TITLE
Feature: Ecommerce Catalog Interactions

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,9 +8,118 @@ const importStorefront = async () => {
   return import('./main');
 };
 
+const getProductNames = (): string[] =>
+  [...document.querySelectorAll('.product-card__title')].map((title) => title.textContent ?? '');
+
 describe('renderStorefront', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+  });
+
+  it('filters products by category', async () => {
+    const { applyCatalogFilters } = await importStorefront();
+
+    const results = applyCatalogFilters(
+      [
+        {
+          id: 'workflow-kit',
+          name: 'AI Workflow Kit',
+          description: 'Reusable prompts, checklists, and templates for product teams.',
+          price: 49,
+          category: 'Templates',
+        },
+        {
+          id: 'research-sprint',
+          name: 'Research Sprint',
+          description: 'A compact discovery package for validating new product directions.',
+          price: 199,
+          category: 'Services',
+        },
+      ],
+      { searchTerm: '', category: 'Services', sort: 'featured' },
+    );
+
+    expect(results.map((product) => product.name)).toEqual(['Research Sprint']);
+  });
+
+  it('searches products by text case-insensitively', async () => {
+    const { applyCatalogFilters } = await importStorefront();
+
+    const results = applyCatalogFilters(
+      [
+        {
+          id: 'model-review',
+          name: 'Model Review Session',
+          description: 'Expert feedback on model behavior, evals, and launch readiness.',
+          price: 299,
+          category: 'Advisory',
+        },
+        {
+          id: 'launch-pack',
+          name: 'Launch Pack',
+          description: 'Storefront-ready assets and operating docs for an AI product release.',
+          price: 129,
+          category: 'Assets',
+        },
+      ],
+      { searchTerm: 'EVALS', category: 'all', sort: 'featured' },
+    );
+
+    expect(results.map((product) => product.name)).toEqual(['Model Review Session']);
+  });
+
+  it('sorts products by price', async () => {
+    const { applyCatalogFilters } = await importStorefront();
+    const sampleProducts = [
+      {
+        id: 'research-sprint',
+        name: 'Research Sprint',
+        description: 'A compact discovery package for validating new product directions.',
+        price: 199,
+        category: 'Services',
+      },
+      {
+        id: 'workflow-kit',
+        name: 'AI Workflow Kit',
+        description: 'Reusable prompts, checklists, and templates for product teams.',
+        price: 49,
+        category: 'Templates',
+      },
+      {
+        id: 'model-review',
+        name: 'Model Review Session',
+        description: 'Expert feedback on model behavior, evals, and launch readiness.',
+        price: 299,
+        category: 'Advisory',
+      },
+    ];
+
+    const ascending = applyCatalogFilters(sampleProducts, {
+      searchTerm: '',
+      category: 'all',
+      sort: 'price-asc',
+    });
+    const descending = applyCatalogFilters(sampleProducts, {
+      searchTerm: '',
+      category: 'all',
+      sort: 'price-desc',
+    });
+
+    expect(ascending.map((product) => product.name)).toEqual([
+      'AI Workflow Kit',
+      'Research Sprint',
+      'Model Review Session',
+    ]);
+    expect(descending.map((product) => product.name)).toEqual([
+      'Model Review Session',
+      'Research Sprint',
+      'AI Workflow Kit',
+    ]);
+    expect(sampleProducts.map((product) => product.name)).toEqual([
+      'Research Sprint',
+      'AI Workflow Kit',
+      'Model Review Session',
+    ]);
   });
 
   it('renders the storefront header', async () => {
@@ -28,6 +137,68 @@ describe('renderStorefront', () => {
     expect(cards).toHaveLength(4);
     expect(document.body.textContent).toContain('AI Workflow Kit');
     expect(document.body.textContent).toContain('Launch Pack');
+  });
+
+  it('renders catalog controls', async () => {
+    await importStorefront();
+
+    expect(document.querySelector('.catalog__controls')).not.toBeNull();
+    expect(document.querySelector<HTMLInputElement>('.catalog__input')?.placeholder).toBe(
+      'Search products',
+    );
+    expect(document.querySelectorAll<HTMLSelectElement>('.catalog__select')).toHaveLength(2);
+  });
+
+  it('updates product cards from the search input', async () => {
+    await importStorefront();
+
+    const searchInput = document.querySelector('.catalog__input') as HTMLInputElement;
+    searchInput.value = 'workflow';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(getProductNames()).toEqual(['AI Workflow Kit']);
+  });
+
+  it('updates product cards from the category select', async () => {
+    await importStorefront();
+
+    const categorySelect = document.querySelector(
+      '.catalog__select[aria-label="Filter by category"]',
+    ) as HTMLSelectElement;
+    categorySelect.value = 'Advisory';
+    categorySelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(getProductNames()).toEqual(['Model Review Session']);
+  });
+
+  it('updates product card order from the sort select', async () => {
+    await importStorefront();
+
+    const sortSelect = document.querySelector(
+      '.catalog__select[aria-label="Sort products"]',
+    ) as HTMLSelectElement;
+    sortSelect.value = 'price-desc';
+    sortSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(getProductNames()).toEqual([
+      'Model Review Session',
+      'Research Sprint',
+      'Launch Pack',
+      'AI Workflow Kit',
+    ]);
+  });
+
+  it('renders an empty catalog message when filters match no products', async () => {
+    await importStorefront();
+
+    const searchInput = document.querySelector('.catalog__input') as HTMLInputElement;
+    searchInput.value = 'nothing matches this query';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(document.querySelectorAll('.product-card')).toHaveLength(0);
+    expect(document.querySelector('.catalog__empty')?.textContent).toBe(
+      'No products match the current filters.',
+    );
   });
 
   it('renders the cart summary placeholder', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,14 @@ type Product = {
   category: string;
 };
 
+export type PriceSort = 'featured' | 'price-asc' | 'price-desc';
+
+export type CatalogFilters = {
+  searchTerm: string;
+  category: string;
+  sort: PriceSort;
+};
+
 const products: Product[] = [
   {
     id: 'workflow-kit',
@@ -45,6 +53,30 @@ const formatPrice = (price: number): string =>
     currency: 'USD',
     maximumFractionDigits: 0,
   }).format(price);
+
+export const applyCatalogFilters = (items: Product[], filters: CatalogFilters): Product[] => {
+  const normalizedSearch = filters.searchTerm.trim().toLowerCase();
+  const filteredItems = items.filter((product) => {
+    const matchesCategory = filters.category === 'all' || product.category === filters.category;
+    const matchesSearch =
+      normalizedSearch.length === 0 ||
+      product.name.toLowerCase().includes(normalizedSearch) ||
+      product.description.toLowerCase().includes(normalizedSearch) ||
+      product.category.toLowerCase().includes(normalizedSearch);
+
+    return matchesCategory && matchesSearch;
+  });
+
+  if (filters.sort === 'price-asc') {
+    return [...filteredItems].sort((first, second) => first.price - second.price);
+  }
+
+  if (filters.sort === 'price-desc') {
+    return [...filteredItems].sort((first, second) => second.price - first.price);
+  }
+
+  return [...filteredItems];
+};
 
 const createElement = <TagName extends keyof HTMLElementTagNameMap>(
   tagName: TagName,
@@ -86,6 +118,12 @@ const createProductCard = (product: Product): HTMLElement => {
 export const renderStorefront = (root: HTMLElement): void => {
   root.textContent = '';
 
+  const currentFilters: CatalogFilters = {
+    searchTerm: '',
+    category: 'all',
+    sort: 'featured',
+  };
+
   const app = createElement('main', 'storefront');
 
   const header = createElement('header', 'storefront-header');
@@ -102,9 +140,81 @@ export const renderStorefront = (root: HTMLElement): void => {
   catalog.setAttribute('aria-labelledby', 'catalog-title');
   const catalogTitle = createElement('h2', 'section-title', 'Featured products');
   catalogTitle.id = 'catalog-title';
+
+  const controls = createElement('div', 'catalog__controls');
+
+  const searchField = createElement('label', 'catalog__field');
+  const searchLabel = createElement('span', 'catalog__label', 'Search');
+  const searchInput = createElement('input', 'catalog__input');
+  searchInput.type = 'search';
+  searchInput.placeholder = 'Search products';
+  searchInput.setAttribute('aria-label', 'Search products');
+  searchField.append(searchLabel, searchInput);
+
+  const categoryField = createElement('label', 'catalog__field');
+  const categoryLabel = createElement('span', 'catalog__label', 'Category');
+  const categorySelect = createElement('select', 'catalog__select');
+  categorySelect.setAttribute('aria-label', 'Filter by category');
+
+  const allCategoriesOption = createElement('option', undefined, 'All categories');
+  allCategoriesOption.value = 'all';
+  categorySelect.append(allCategoriesOption);
+  [...new Set(products.map((product) => product.category))].forEach((category) => {
+    const option = createElement('option', undefined, category);
+    option.value = category;
+    categorySelect.append(option);
+  });
+  categoryField.append(categoryLabel, categorySelect);
+
+  const sortField = createElement('label', 'catalog__field');
+  const sortLabel = createElement('span', 'catalog__label', 'Sort');
+  const sortSelect = createElement('select', 'catalog__select');
+  sortSelect.setAttribute('aria-label', 'Sort products');
+
+  [
+    { value: 'featured', label: 'Featured' },
+    { value: 'price-asc', label: 'Price: low to high' },
+    { value: 'price-desc', label: 'Price: high to low' },
+  ].forEach((sortOption) => {
+    const option = createElement('option', undefined, sortOption.label);
+    option.value = sortOption.value;
+    sortSelect.append(option);
+  });
+  sortField.append(sortLabel, sortSelect);
+  controls.append(searchField, categoryField, sortField);
+
   const productGrid = createElement('div', 'product-grid');
-  products.forEach((product) => productGrid.append(createProductCard(product)));
-  catalog.append(catalogTitle, productGrid);
+
+  const renderProducts = (): void => {
+    productGrid.textContent = '';
+
+    const visibleProducts = applyCatalogFilters(products, currentFilters);
+
+    if (visibleProducts.length === 0) {
+      productGrid.append(
+        createElement('p', 'catalog__empty', 'No products match the current filters.'),
+      );
+      return;
+    }
+
+    visibleProducts.forEach((product) => productGrid.append(createProductCard(product)));
+  };
+
+  searchInput.addEventListener('input', () => {
+    currentFilters.searchTerm = searchInput.value;
+    renderProducts();
+  });
+  categorySelect.addEventListener('change', () => {
+    currentFilters.category = categorySelect.value;
+    renderProducts();
+  });
+  sortSelect.addEventListener('change', () => {
+    currentFilters.sort = sortSelect.value as PriceSort;
+    renderProducts();
+  });
+
+  renderProducts();
+  catalog.append(catalogTitle, controls, productGrid);
 
   const checkoutArea = createElement('section', 'storefront-panels');
   checkoutArea.setAttribute('aria-label', 'Cart and checkout');

--- a/src/styles.css
+++ b/src/styles.css
@@ -79,11 +79,54 @@ button {
   letter-spacing: 0;
 }
 
+.catalog__controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.5fr) repeat(2, minmax(180px, 1fr));
+  gap: 14px;
+  align-items: end;
+  margin-top: 18px;
+}
+
+.catalog__field {
+  display: grid;
+  gap: 6px;
+}
+
+.catalog__label {
+  color: #5a5f68;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.catalog__input,
+.catalog__select {
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid #d9d2c4;
+  border-radius: 8px;
+  background: #fffdf8;
+  color: #1c1d20;
+  font: inherit;
+  padding: 0 12px;
+}
+
+.catalog__input:focus,
+.catalog__select:focus {
+  border-color: #1f5f68;
+  outline: 2px solid rgb(31 95 104 / 0.18);
+  outline-offset: 2px;
+}
+
 .product-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
   gap: 16px;
   margin-top: 16px;
+}
+
+.catalog__empty {
+  margin: 0;
+  color: #626873;
 }
 
 .product-card,
@@ -198,6 +241,10 @@ button {
   }
 
   .storefront-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog__controls {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Add small, client-side catalog browsing behavior to the existing vanilla TypeScript storefront. The implementation stays within the current skeleton by adding pure catalog query helpers, imperative DOM controls, focused jsdom/Vitest coverage, and minimal responsive CSS.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/main.ts` | UPDATE | Added exported catalog filter/sort types and `applyCatalogFilters`, then wired search, category filtering, price sorting, and empty-state rendering into the storefront catalog. |
| `src/main.test.ts` | UPDATE | Added helper tests and DOM interaction tests for category filtering, case-insensitive search, price sorting, control rendering, catalog updates, and empty state behavior. |
| `src/styles.css` | UPDATE | Added responsive catalog control, input, select, focus, and empty-state styles that fit the existing storefront layout. |

## Tests

- `src/main.test.ts` - `filters products by category`
- `src/main.test.ts` - `searches products by text case-insensitively`
- `src/main.test.ts` - `sorts products by price`
- `src/main.test.ts` - `renders catalog controls`
- `src/main.test.ts` - `updates product cards from the search input`
- `src/main.test.ts` - `updates product cards from the category select`
- `src/main.test.ts` - `updates product card order from the sort select`
- `src/main.test.ts` - `renders an empty catalog message when filters match no products`

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] All tests pass (12 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

No deviations. Implementation matched the plan exactly.

### Issues Resolved

- Search UI test initially used `launch`, which matched multiple products because descriptions are searchable. The test now uses `workflow`, which uniquely matches `AI Workflow Kit`.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/2b6e6a32343e2801d443b79b7a61fe3c/plan.md`
**Workflow ID**: `2b6e6a32343e2801d443b79b7a61fe3c`
Fixes #111
