### PR TITLE
Feature: Ecommerce Catalog Interactions

### DIFF
--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { getCatalogProducts, getCategories } from "./catalog";
+import { products } from "./products";
+
+describe("catalog", () => {
+  it("returns unique categories in first-seen order", () => {
+    expect(getCategories(products)).toEqual([
+      "Bags",
+      "Apparel",
+      "Home",
+      "Office",
+    ]);
+  });
+
+  it("filters products by category", () => {
+    const results = getCatalogProducts(products, {
+      category: "Home",
+      query: "",
+      sort: "featured",
+    });
+
+    expect(results.map((product) => product.id)).toEqual(["ceramic-mug-set"]);
+  });
+
+  it("searches product names and descriptions case-insensitively", () => {
+    const nameResults = getCatalogProducts(products, {
+      category: "all",
+      query: "LiNeN",
+      sort: "featured",
+    });
+    const descriptionResults = getCatalogProducts(products, {
+      category: "all",
+      query: "MATTE GLAZE",
+      sort: "featured",
+    });
+
+    expect(nameResults.map((product) => product.id)).toEqual([
+      "linen-overshirt",
+    ]);
+    expect(descriptionResults.map((product) => product.id)).toEqual([
+      "ceramic-mug-set",
+    ]);
+  });
+
+  it("sorts products by price ascending and descending", () => {
+    const ascending = getCatalogProducts(products, {
+      category: "all",
+      query: "",
+      sort: "price-asc",
+    });
+    const descending = getCatalogProducts(products, {
+      category: "all",
+      query: "",
+      sort: "price-desc",
+    });
+
+    expect(ascending.map((product) => product.id)).toEqual([
+      "desk-planner",
+      "ceramic-mug-set",
+      "linen-overshirt",
+      "studio-backpack",
+    ]);
+    expect(descending.map((product) => product.id)).toEqual([
+      "studio-backpack",
+      "linen-overshirt",
+      "ceramic-mug-set",
+      "desk-planner",
+    ]);
+  });
+
+  it("does not mutate the original product order when sorting", () => {
+    const originalOrder = products.map((product) => product.id);
+
+    getCatalogProducts(products, {
+      category: "all",
+      query: "",
+      sort: "price-asc",
+    });
+
+    expect(products.map((product) => product.id)).toEqual(originalOrder);
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,0 +1,47 @@
+import type { Product } from "./products";
+
+export type CatalogSort = "featured" | "price-asc" | "price-desc";
+
+export type CatalogFilters = {
+  category: "all" | Product["category"];
+  query: string;
+  sort: CatalogSort;
+};
+
+export const defaultCatalogFilters: CatalogFilters = {
+  category: "all",
+  query: "",
+  sort: "featured",
+};
+
+export function getCategories(productList: Product[]): Product["category"][] {
+  return Array.from(new Set(productList.map((product) => product.category)));
+}
+
+export function getCatalogProducts(
+  productList: Product[],
+  filters: CatalogFilters,
+): Product[] {
+  const query = filters.query.trim().toLowerCase();
+
+  const results = productList.filter((product) => {
+    const matchesCategory =
+      filters.category === "all" || product.category === filters.category;
+    const matchesQuery =
+      query.length === 0 ||
+      product.name.toLowerCase().includes(query) ||
+      product.description.toLowerCase().includes(query);
+
+    return matchesCategory && matchesQuery;
+  });
+
+  if (filters.sort === "featured") {
+    return results;
+  }
+
+  return [...results].sort((firstProduct, secondProduct) => {
+    const priceDifference = firstProduct.priceCents - secondProduct.priceCents;
+
+    return filters.sort === "price-asc" ? priceDifference : -priceDifference;
+  });
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -21,6 +21,7 @@ describe("storefront", () => {
       id: "test-product",
       name: "Test Product",
       description: "Useful test merchandise.",
+      category: "Office",
       priceCents: 1299,
     };
 
@@ -59,6 +60,73 @@ describe("storefront", () => {
     expect(root.querySelector("button:disabled")?.textContent).toBe(
       "Checkout placeholder",
     );
+  });
+
+  it("renders catalog category, search, and sort controls", () => {
+    const root = document.createElement("div");
+
+    renderStorefront(root);
+
+    expect(root.querySelector('select[name="category"]')).not.toBeNull();
+    expect(root.querySelector('input[name="search"]')).not.toBeNull();
+    expect(root.querySelector('select[name="sort"]')).not.toBeNull();
+    expect(root.textContent).toContain("All categories");
+    expect(root.textContent).toContain("Price: low to high");
+  });
+
+  it("filters product cards when category changes", () => {
+    const root = document.createElement("div");
+
+    renderStorefront(root);
+
+    const categorySelect = root.querySelector<HTMLSelectElement>(
+      'select[name="category"]',
+    );
+    categorySelect!.value = "Home";
+    categorySelect!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const cards = root.querySelectorAll<HTMLElement>(".product-card");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.dataset.productId).toBe("ceramic-mug-set");
+  });
+
+  it("filters product cards when a search query is typed", () => {
+    const root = document.createElement("div");
+
+    renderStorefront(root);
+
+    const searchInput = root.querySelector<HTMLInputElement>(
+      'input[name="search"]',
+    );
+    searchInput!.value = "planner";
+    searchInput!.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const cards = root.querySelectorAll<HTMLElement>(".product-card");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.dataset.productId).toBe("desk-planner");
+  });
+
+  it("updates product card order when price sort changes", () => {
+    const root = document.createElement("div");
+
+    renderStorefront(root);
+
+    const sortSelect = root.querySelector<HTMLSelectElement>(
+      'select[name="sort"]',
+    );
+    sortSelect!.value = "price-asc";
+    sortSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(
+      Array.from(root.querySelectorAll<HTMLElement>(".product-card")).map(
+        (card) => card.dataset.productId,
+      ),
+    ).toEqual([
+      "desk-planner",
+      "ceramic-mug-set",
+      "linen-overshirt",
+      "studio-backpack",
+    ]);
   });
 
   it("renders an empty catalog state without crashing", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,12 @@
 import "./styles.css";
 
+import {
+  defaultCatalogFilters,
+  getCatalogProducts,
+  getCategories,
+  type CatalogFilters,
+  type CatalogSort,
+} from "./catalog";
 import { products, type Product } from "./products";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -40,6 +47,120 @@ export function renderProductCard(product: Product): HTMLElement {
   return card;
 }
 
+export function updateProductGrid(
+  productGrid: HTMLElement,
+  productList: Product[],
+): void {
+  productGrid.replaceChildren();
+
+  if (productList.length === 0) {
+    const emptyState = document.createElement("p");
+    emptyState.className = "catalog__empty";
+    emptyState.textContent = "No products are available yet.";
+    productGrid.append(emptyState);
+  } else {
+    productGrid.append(
+      ...productList.map((product) => renderProductCard(product)),
+    );
+  }
+}
+
+export function renderCatalogControls(
+  productList: Product[],
+  filters: CatalogFilters,
+  onChange: (filters: CatalogFilters) => void,
+): HTMLElement {
+  let currentFilters = filters;
+
+  const controls = document.createElement("div");
+  controls.className = "catalog__controls";
+
+  const categoryLabel = document.createElement("label");
+  categoryLabel.className = "catalog__control";
+  categoryLabel.textContent = "Category";
+
+  const categorySelect = document.createElement("select");
+  categorySelect.name = "category";
+
+  const allCategoryOption = document.createElement("option");
+  allCategoryOption.value = "all";
+  allCategoryOption.textContent = "All categories";
+  categorySelect.append(allCategoryOption);
+
+  categorySelect.append(
+    ...getCategories(productList).map((category) => {
+      const option = document.createElement("option");
+      option.value = category;
+      option.textContent = category;
+
+      return option;
+    }),
+  );
+  categorySelect.value = filters.category;
+
+  const searchLabel = document.createElement("label");
+  searchLabel.className = "catalog__control";
+  searchLabel.textContent = "Search";
+
+  const searchInput = document.createElement("input");
+  searchInput.name = "search";
+  searchInput.type = "search";
+  searchInput.placeholder = "Search products";
+  searchInput.value = filters.query;
+
+  const sortLabel = document.createElement("label");
+  sortLabel.className = "catalog__control";
+  sortLabel.textContent = "Sort";
+
+  const sortSelect = document.createElement("select");
+  sortSelect.name = "sort";
+
+  const sortOptions: { label: string; value: CatalogSort }[] = [
+    { label: "Featured", value: "featured" },
+    { label: "Price: low to high", value: "price-asc" },
+    { label: "Price: high to low", value: "price-desc" },
+  ];
+
+  sortSelect.append(
+    ...sortOptions.map((sortOption) => {
+      const option = document.createElement("option");
+      option.value = sortOption.value;
+      option.textContent = sortOption.label;
+
+      return option;
+    }),
+  );
+  sortSelect.value = filters.sort;
+
+  categorySelect.addEventListener("change", () => {
+    currentFilters = {
+      ...currentFilters,
+      category: categorySelect.value as CatalogFilters["category"],
+    };
+    onChange(currentFilters);
+  });
+
+  searchInput.addEventListener("input", () => {
+    currentFilters = { ...currentFilters, query: searchInput.value };
+    onChange(currentFilters);
+  });
+
+  sortSelect.addEventListener("change", () => {
+    currentFilters = {
+      ...currentFilters,
+      sort: sortSelect.value as CatalogSort,
+    };
+    onChange(currentFilters);
+  });
+
+  categoryLabel.append(categorySelect);
+  searchLabel.append(searchInput);
+  sortLabel.append(sortSelect);
+  controls.append(categoryLabel, searchLabel, sortLabel);
+
+  return controls;
+}
+
 export function renderStorefront(
   root: HTMLElement,
   productList = products,
@@ -76,21 +197,23 @@ export function renderStorefront(
   catalogHeading.id = "catalog-heading";
   catalogHeading.textContent = "Products";
 
+  let filters: CatalogFilters = { ...defaultCatalogFilters };
+
   const productGrid = document.createElement("div");
   productGrid.className = "product-grid";
 
-  if (productList.length === 0) {
-    const emptyState = document.createElement("p");
-    emptyState.className = "catalog__empty";
-    emptyState.textContent = "No products are available yet.";
-    productGrid.append(emptyState);
-  } else {
-    productGrid.append(
-      ...productList.map((product) => renderProductCard(product)),
-    );
-  }
+  const catalogControls = renderCatalogControls(
+    productList,
+    filters,
+    (nextFilters) => {
+      filters = nextFilters;
+      updateProductGrid(productGrid, getCatalogProducts(productList, filters));
+    },
+  );
 
-  catalogSection.append(catalogHeading, productGrid);
+  updateProductGrid(productGrid, getCatalogProducts(productList, filters));
+
+  catalogSection.append(catalogHeading, catalogControls, productGrid);
 
   const sidebar = document.createElement("aside");
   sidebar.className = "checkout-panel";

--- a/src/products.ts
+++ b/src/products.ts
@@ -1,7 +1,10 @@
+export type ProductCategory = "Bags" | "Apparel" | "Home" | "Office";
+
 export type Product = {
   id: string;
   name: string;
   description: string;
+  category: ProductCategory;
   priceCents: number;
 };
 
@@ -10,24 +13,28 @@ export const products: Product[] = [
     id: "studio-backpack",
     name: "Studio Backpack",
     description: "A compact everyday pack with organized space for work gear.",
+    category: "Bags",
     priceCents: 9800,
   },
   {
     id: "linen-overshirt",
     name: "Linen Overshirt",
     description: "A breathable layer for warm days and cool evenings.",
+    category: "Apparel",
     priceCents: 7450,
   },
   {
     id: "ceramic-mug-set",
     name: "Ceramic Mug Set",
     description: "Two stackable mugs with a soft matte glaze.",
+    category: "Home",
     priceCents: 3200,
   },
   {
     id: "desk-planner",
     name: "Desk Planner",
     description: "A weekly planner with durable paper and a lay-flat spine.",
+    category: "Office",
     priceCents: 1850,
   },
 ];

--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,35 @@ button:disabled {
   margin: 0;
 }
 
+.catalog__controls {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: minmax(160px, 0.8fr) minmax(220px, 1.4fr) minmax(
+      160px,
+      0.8fr
+    );
+  margin-top: 1rem;
+}
+
+.catalog__control {
+  color: #555c57;
+  display: grid;
+  font-size: 0.85rem;
+  font-weight: 700;
+  gap: 0.35rem;
+}
+
+.catalog__control input,
+.catalog__control select {
+  width: 100%;
+  border: 1px solid #ded9ce;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #202124;
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+}
+
 .product-grid {
   display: grid;
   gap: 1rem;
@@ -154,6 +183,10 @@ button:disabled {
   }
 
   .storefront__content {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog__controls {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Add real catalog browsing behavior to the existing minimal Vite + TypeScript storefront. Product data now includes categories, pure catalog utilities handle category filtering, text search, and price sorting, and the storefront renders controls that update the product grid without changing cart and checkout placeholders.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/products.ts` | UPDATE | Added a narrow `ProductCategory` union and category values for each fixture product. |
| `src/catalog.ts` | CREATE | Added pure helpers for category listing, category filtering, case-insensitive text search, and featured/price sorting. |
| `src/main.ts` | UPDATE | Added catalog controls and grid update logic while preserving product card rendering and checkout/cart placeholders. |
| `src/styles.css` | UPDATE | Added responsive styles for the compact catalog control bar. |
| `src/catalog.test.ts` | CREATE | Added focused catalog utility coverage. |
| `src/main.test.ts` | UPDATE | Added DOM integration coverage for controls, filtering, search, sorting, and the existing product fixture type. |

## Tests

- `src/catalog.test.ts` - covers first-seen category listing, category filtering, case-insensitive name/description search, ascending/descending price sorting, and source list non-mutation.
- `src/main.test.ts` - covers rendering the catalog controls, filtering by category, filtering by typed search query, and updating product card order when price sorting changes.

## Validation

- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] All tests pass (15 tests)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

- PR publishing was deferred from the implementation workflow and completed in this finalize workflow.

### Issues Resolved

- Added `category: "Office"` to the inline `Product` fixture in `src/main.test.ts` after the product type was extended.
- Ran formatting after TypeScript edits and re-ran the full validation set successfully.

---

**Plan**: `/home/ubuntu/.archon/workspaces/podlodka-ai-club/X15/artifacts/runs/3ca785ddf804f54b9a309e5a89c3af9d/plan.md`
**Workflow ID**: `3ca785ddf804f54b9a309e5a89c3af9d`
Fixes #126
